### PR TITLE
Fix event unsubscriptions by removing callback function overriding

### DIFF
--- a/src/components/Vocal.js
+++ b/src/components/Vocal.js
@@ -28,8 +28,16 @@ const Vocal = ({
 }) => {
 	const [isListening, setIsListening] = useState(false)
 
-	const [, {start, stop, subscribe, unsubscribe}] = useVocal(lang, grammars, __rsInstance)
-	const [startTimer, stopTimer] = useTimeout(() => _onEnd(), timeout)
+	const [, { start, stop, subscribe, unsubscribe }] = useVocal(lang, grammars, __rsInstance)
+
+	const _onEnd = (e) => {
+		stopTimer()
+		stopRecognition()
+
+		!!onEnd && onEnd(e)
+	}
+
+	const [startTimer, stopTimer] = useTimeout(_onEnd, timeout)
 
 	const startRecognition = () => {
 		try {
@@ -75,13 +83,6 @@ const Vocal = ({
 		!!onStart && onStart(e)
 	}
 
-	const _onEnd = (e) => {
-		stopTimer()
-		stopRecognition()
-
-		!!onEnd && onEnd(e)
-	}
-
 	const _onSpeechStart = (e) => {
 		stopTimer()
 
@@ -95,6 +96,7 @@ const Vocal = ({
 	}
 
 	const _onResult = (result, event) => {
+		stopTimer()
 		stopRecognition()
 
 		!!onResult && onResult(result, event)
@@ -107,6 +109,9 @@ const Vocal = ({
 	}
 
 	const _onNoMatch = (e) => {
+		stopTimer()
+		stopRecognition()
+
 		!!onNoMatch && onNoMatch(e)
 	}
 

--- a/src/core/SpeechRecognitionWrapper.js
+++ b/src/core/SpeechRecognitionWrapper.js
@@ -95,15 +95,15 @@ class SpeechRecognitionWrapper {
 		return this
 	}
 
-	addEventListener(type, callback) {
-		if (!!this._instance && this._includesEventType(type)) {
-			if (!!this._listeners[type]) {
-				this.removeEventListener(type)
+	addEventListener(eventType, callback) {
+		if (!!this._instance && this._includesEventType(eventType)) {
+			if (!!this._listeners[eventType]) {
+				this.removeEventListener(eventType)
 			}
 
 			const handler = (event) => {
 				let additionalArgs = []
-				if (type === SpeechRecognitionWrapper.eventTypes.RESULT) {
+				if (eventType === SpeechRecognitionWrapper.eventTypes.RESULT) {
 					if (!!event.results && event.results.length > 0) {
 						additionalArgs.push(event.results[0][0].transcript)
 					}
@@ -111,19 +111,19 @@ class SpeechRecognitionWrapper {
 
 				!!callback && callback.apply(this, [...additionalArgs, event])
 			}
-			this._instance.addEventListener(type, (e) => handler(e))
+			this._instance.addEventListener(eventType, handler)
 
-			this._listeners[type] = handler
+			this._listeners[eventType] = handler
 		}
 
 		return this
 	}
 
-	removeEventListener(type) {
-		const handler = this._listeners[type]
-		this._instance.removeEventListener(type, handler)
+	removeEventListener(eventType) {
+		const handler = this._listeners[eventType]
+		this._instance.removeEventListener(eventType, handler)
 
-		delete this._listeners[type]
+		delete this._listeners[eventType]
 
 		return this
 	}
@@ -138,7 +138,7 @@ class SpeechRecognitionWrapper {
 	}
 
 	_includesEventType(eventType) {
-		return Object.values(SpeechRecognitionWrapper.eventTypes).find((type) => type === eventType)
+		return !!Object.values(SpeechRecognitionWrapper.eventTypes).find((type) => type === eventType)
 	}
 
 	static _resolveSpeechRecognition() {

--- a/src/hooks/useVocal.js
+++ b/src/hooks/useVocal.js
@@ -33,15 +33,15 @@ const useVocal = (lang = 'en-US', grammars = null, __rsInstance = null) => {
 		}
 	}, [])
 
-	const subscribe = useCallback((event, handler) => {
+	const subscribe = useCallback((eventType, handler) => {
 		if (ref.current) {
-			ref.current.addEventListener(event, handler)
+			ref.current.addEventListener(eventType, handler)
 		}
 	}, [])
 
-	const unsubscribe = useCallback((event, handler) => {
+	const unsubscribe = useCallback((eventType, handler) => {
 		if (ref.current) {
-			ref.current.removeEventListener(event, handler)
+			ref.current.removeEventListener(eventType, handler)
 		}
 	}, [])
 


### PR DESCRIPTION
When subscribing to a SpeechRecognitionWrapper event, the callback was overridden by creating another function which was not registered in the listeners array. Later the callback passed to unsubscription was not retrieved.