### PR TITLE
feat(vocal): Aggregate all result segments picking highest-confidence alternative

### DIFF
--- a/src/components/Vocal.jsx
+++ b/src/components/Vocal.jsx
@@ -168,7 +168,6 @@ const Vocal = ({
 		}
 	}
 
-
 	const _renderDefault = () => (
 		<button
 			data-testid="__vocal-root__"

--- a/src/components/Vocal.jsx
+++ b/src/components/Vocal.jsx
@@ -82,11 +82,22 @@ const Vocal = ({
 	)
 
 	const _onResult = useCallback(
-		(event, result) => {
+		(event) => {
+			const transcript = Array.from(event?.results ?? [], (segment) => {
+				let best = { confidence: -Infinity, transcript: '' }
+				for (let j = 0; j < segment.length; j++) {
+					const alt = segment[j]
+					if (alt.confidence === undefined || alt.confidence > best.confidence) {
+						best = alt
+					}
+				}
+				return best.transcript ?? ''
+			}).join('')
+
 			stopTimer()
 			stopRecognition()
-			triggerCommandRef.current(result)
-			propsRef.current.onResult?.(result, event)
+			triggerCommandRef.current(transcript)
+			propsRef.current.onResult?.(transcript, event)
 		},
 		[stopTimer, stopRecognition]
 	)
@@ -156,6 +167,7 @@ const Vocal = ({
 			buttonRef.current.style.outline = 'none'
 		}
 	}
+
 
 	const _renderDefault = () => (
 		<button

--- a/src/components/__tests__/Vocal.test.jsx
+++ b/src/components/__tests__/Vocal.test.jsx
@@ -427,4 +427,50 @@ describe('Vocal', () => {
 
 		expect(onErrorV1).not.toHaveBeenCalled()
 	})
+
+	it('returns the most confident alternative when multiple alternatives are provided', async () => {
+		const onResult = vi.fn()
+		const recognition = new SpeechRecognitionWrapper()
+		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onResult }))
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+			recognition.instance.say([[
+				{ transcript: 'bar', confidence: 0.4 },
+				{ transcript: 'foo', confidence: 0.9 },
+				{ transcript: 'baz', confidence: 0.1 },
+			]])
+			await waitFor(() => expect(onResult).toHaveBeenCalledWith('foo', expect.anything()))
+		})
+	})
+
+	it('joins all segments when multiple result segments are provided', async () => {
+		const onResult = vi.fn()
+		const recognition = new SpeechRecognitionWrapper()
+		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onResult }))
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+			recognition.instance.say([
+				[{ transcript: 'hello ', confidence: 0.9 }],
+				[{ transcript: 'world', confidence: 0.8 }],
+			])
+			await waitFor(() => expect(onResult).toHaveBeenCalledWith('hello world', expect.anything()))
+		})
+	})
+
+	it('picks highest-confidence alternative per segment when multi-segment with multi-alternative', async () => {
+		const onResult = vi.fn()
+		const recognition = new SpeechRecognitionWrapper()
+		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onResult }))
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+			recognition.instance.say([
+				[{ transcript: 'good ', confidence: 0.8 }, { transcript: 'bad ', confidence: 0.2 }],
+				[{ transcript: 'day', confidence: 0.95 }, { transcript: 'dey', confidence: 0.3 }],
+			])
+			await waitFor(() => expect(onResult).toHaveBeenCalledWith('good day', expect.anything()))
+		})
+	})
 })

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -59,7 +59,6 @@ global.SpeechRecognition = vi.fn(function () {
 
 			const resultEvent = new Event('result')
 			resultEvent.resultIndex = 0
-			// input: null (nomatch) | string (single result) | array of result arrays (multi-segment/alternative)
 			resultEvent.results = Array.isArray(input) ? input : input ? [[{ transcript: input }]] : []
 			handlers.speechend?.()
 			if (input) {

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -54,14 +54,15 @@ global.SpeechRecognition = vi.fn(function () {
 		abort: vi.fn(function () {
 			handlers.end?.()
 		}),
-		say: vi.fn(function (sentence) {
+		say: vi.fn(function (input) {
 			handlers.speechstart?.()
 
 			const resultEvent = new Event('result')
 			resultEvent.resultIndex = 0
-			resultEvent.results = [[{ transcript: sentence }]]
+			// input: null (nomatch) | string (single result) | array of result arrays (multi-segment/alternative)
+			resultEvent.results = Array.isArray(input) ? input : input ? [[{ transcript: input }]] : []
 			handlers.speechend?.()
-			if (sentence) {
+			if (input) {
 				handlers.result?.(resultEvent)
 			} else {
 				handlers.nomatch?.()


### PR DESCRIPTION
## Summary

Fixes the result handler to correctly aggregate all speech recognition result segments and select the most confident alternative per segment, instead of always returning the first alternative of the first segment only.

The raw `SpeechRecognitionEvent` is already available in `_onResult` — the pre-processed string from `@untemps/vocal` (which only exposes `results[0][0].transcript`) is replaced by a local aggregation over `event.results`.

## Changes

- `src/components/Vocal.jsx` — `_onResult` iterates over all segments in `event.results`, picks the highest-confidence alternative per segment (falling back to the first when `confidence` is `undefined`), and joins all transcripts
- `vitest.setup.js` — `say()` mock extended to accept an array of result arrays for multi-segment/multi-alternative testing, in addition to the existing string shorthand
- `src/components/__tests__/Vocal.test.jsx` — three new tests covering multi-alternative selection, multi-segment joining, and combined multi-segment/multi-alternative scenarios

## Test plan

- [ ] Existing `triggers onResult handler` test still passes (string shorthand backward compat)
- [ ] New: most confident alternative selected from multiple alternatives
- [ ] New: multiple segments joined into a single string
- [ ] New: highest-confidence alternative per segment across multiple segments

Closes #37