### PR TITLE
fix(package): Add files field to include dist/ in npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"files": [
+		"dist"
+	],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
 		"access": "public"
 	},
 	"files": [
-		"dist"
+		"dist/index.js",
+		"dist/index.es.js",
+		"dist/index.umd.js",
+		"CHANGELOG.md"
 	],
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",


### PR DESCRIPTION
## Summary
`dist/` was listed in `.gitignore` with no `files` field and no `.npmignore`. npm falls back to `.gitignore` when neither is present, which caused the built distribution files to be excluded from the published package. Consumers installing the package would get a tarball with no entry points.

## Changes
- `package.json` — add `"files": ["dist"]` to explicitly include the built output regardless of `.gitignore`

## Test plan
- [ ] `yarn test:ci` passes
- [ ] `yarn build` succeeds
- [ ] `npm pack --dry-run` shows `dist/index.js`, `dist/index.es.js`, `dist/index.umd.js` in the tarball

Closes #119