### PR TITLE
feat!: Migrate to @untemps/vocal 2.x functional API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,19 +21,19 @@ Build formats defined in `vite.config.js` `build.lib`: `cjs` → `dist/index.js`
 
 ## Architecture
 
-React library wrapping the [Web Speech API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API) via `@untemps/vocal` (the `SpeechRecognitionWrapper` class).
+React library wrapping the [Web Speech API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API) via `@untemps/vocal` 2.x (functional API: `createVocal`, `isSupported`, `on`/`off`).
 
 ### Public API (`src/index.js`)
 
 - **`Vocal`** (default export) — the component
 - **`useVocal`** — named export, the hook
-- **`isSupported`** — boolean re-exported from `@untemps/vocal`
+- **`isSupported`** — function re-exported from `@untemps/vocal` (call it: `isSupported()`)
 
 ### Hook layer (`src/hooks/`)
 
 | Hook | Role |
 |------|------|
-| `useVocal` | Creates/manages a `SpeechRecognitionWrapper` instance in a ref. Returns `[ref, { start, stop, abort, subscribe, unsubscribe, clean }]`. Instance is re-created when `lang` or `grammars` change. |
+| `useVocal` | Creates/manages a vocal instance (`createVocal()` from `@untemps/vocal`) in a ref. Returns `[ref, { start, stop, abort, subscribe, unsubscribe, clean }]`. Instance is re-created when `lang` or `grammars` change. `subscribe`/`unsubscribe` delegate to the instance's `on`/`off`. |
 | `useCommands` | Fuzzy-matches a speech result string against a `commands` map using **fuse.js** (default score threshold `0.4` — lower = stricter). Keys are lowercased. |
 | `useTimeout` | Manages the recognition timeout: starts on `start` event, pauses on `speechstart`, restarts on `speechend`, fires `_onEnd` on expiry. |
 
@@ -46,11 +46,11 @@ Composes the three hooks above. Three render modes depending on `children`:
 
 All props have default values in the function signature (React 19: `defaultProps` no longer applied to function components). No `propTypes` — removed as deprecated in React 19.
 
-The `__rsInstance` prop (undocumented) injects a custom `SpeechRecognitionWrapper` instance, used exclusively in tests.
+The `__rsInstance` prop (undocumented) injects a custom vocal instance, used exclusively in tests.
 
 ### Testing
 
-`vitest.setup.js` globally mocks `SpeechRecognition`, `Permissions`, `MediaDevices`, and `SpeechGrammarList`. The mock exposes a custom `say(sentence)` method that fires the full `speechstart → result/nomatch → speechend` event sequence synchronously — use it to simulate recognition in tests.
+`vitest.setup.js` globally mocks `SpeechRecognition`, `Permissions`, `MediaDevices`, and `SpeechGrammarList`. The mock exposes a custom `say(sentence)` method that fires the full `speechstart → result/nomatch → speechend` event sequence synchronously — use it to simulate recognition in tests. The last `SpeechRecognition` instance created by the mock is reachable via `globalThis.__getSpeechRecognition()` (the wrapper's `.instance` getter was removed in vocal 2.x).
 
 Vitest globals are enabled (`globals: true`) — `describe`, `it`, `expect`, `vi` available without imports in test files.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ```bash
 yarn test           # watch mode (Vitest)
 yarn test:ci        # CI mode with coverage (also runs in pre-commit hook)
-yarn build          # build CJS + ES + UMD to dist/ (Vite library mode)
+yarn build          # build CJS + ES to dist/ (Vite library mode)
 yarn dev            # dev server at http://localhost:10001/ (separate dev/ package)
 yarn prettier       # format all JS files and stage tracked changes
 ```
@@ -17,7 +17,7 @@ Run a single test file:
 yarn vitest src/hooks/__tests__/useVocal.test.js
 ```
 
-Build formats defined in `vite.config.js` `build.lib`: `cjs` → `dist/index.js`, `es` → `dist/index.es.js`, `umd` → `dist/index.umd.js`.
+Build formats defined in `vite.config.js` `build.lib`: `cjs` → `dist/index.js`, `es` → `dist/index.es.js`.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ timeout elapses.
 Some browsers supports the `SpeechRecognition` API but not all the related APIs.  
 For example, browsers on iOS 14.5, the `SpeechGrammar` and `SpeechGrammarList` and `Permissions` APIs are not supported.
 
-Although the lack of `SpeechGrammar` and `SpeechGrammarList` is handled by the underlaying `@untemps/vocal` library, you need to deal with `Permissions` by yourself.
+Although the lack of `SpeechGrammar` and `SpeechGrammarList` is handled by the underlying `@untemps/vocal` library, you need to deal with `Permissions` by yourself.
 
 ## Requirements
 
@@ -320,7 +320,7 @@ const [ref, { start, stop, abort, subscribe, unsubscribe, clean }]
 
 | Args        | Type | Description                                          |
 | ----------- | ---- | ---------------------------------------------------- |
-| ref         | Ref  | React ref to the SpeechRecognitionWrapper instance   |
+| ref         | Ref  | React ref to the underlying `@untemps/vocal` instance |
 | start       | func | Function to start the recognition                    |
 | stop        | func | Function to stop the recognition                     |
 | abort       | func | Function to abort the recognition                    |
@@ -332,11 +332,13 @@ const [ref, { start, stop, abort, subscribe, unsubscribe, clean }]
 
 #### Basic usage
 
+`isSupported` is a function that returns `true` when the browser supports the Web Speech API (along with the Permissions and MediaDevices APIs that `@untemps/vocal` relies on). It is safe to call during server-side rendering — it returns `false` when `window` is undefined.
+
 ```javascript
 import Vocal, { isSupported } from '@untemps/react-vocal'
 
 const App = () => {
-	return isSupported ? <Vocal /> : <p>Your browser does not support Web Speech API</p>
+	return isSupported() ? <Vocal /> : <p>Your browser does not support Web Speech API</p>
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ fuse.js is an optional peer dependency — install it separately to enable fuzzy
 | onResult      | func              | null                 | Handler called when a result is recognized                                                      |
 | onError       | func              | null                 | Handler called when an error occurs                                                             |
 | onNoMatch     | func              | null                 | Handler called when no result can be recognized                                                 |
+| signal        | AbortSignal       | null                 | Optional `AbortSignal` propagated to the underlying `start()` call. Aborting it cancels the in-flight start (e.g. while waiting for microphone permission). |
 
 ### `useVocal` hook
 
@@ -321,12 +322,26 @@ const [ref, { start, stop, abort, subscribe, unsubscribe, clean }]
 | Args        | Type | Description                                          |
 | ----------- | ---- | ---------------------------------------------------- |
 | ref         | Ref  | React ref to the underlying `@untemps/vocal` instance |
-| start       | func | Function to start the recognition                    |
+| start       | func | Function to start the recognition. Accepts an optional `{ signal }` argument — an `AbortSignal` propagated to the underlying `start()` call. |
 | stop        | func | Function to stop the recognition                     |
 | abort       | func | Function to abort the recognition                    |
 | subscribe   | func | Function to subscribe to recognition events          |
 | unsubscribe | func | Function to unsubscribe to recognition events        |
 | clean       | func | Function to clean subscription to recognition events |
+
+#### Cancelling a start in flight
+
+Both `<Vocal signal={...}>` and `useVocal().start({ signal })` accept an `AbortSignal`. Aborting the controller while the browser is still resolving microphone permission cancels the start cleanly — no `start` event is dispatched.
+
+```javascript
+const controller = new AbortController()
+
+// Cancel pending recognition after 2s of waiting for permission
+setTimeout(() => controller.abort(), 2000)
+
+const [, { start }] = useVocal('en-US')
+start({ signal: controller.signal })
+```
 
 ### Browser support flag
 

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ useVocal(lang, grammars, maxAlternatives, continuous)
 #### Return value
 
 ```
-const [ref, { start, stop, abort, subscribe, unsubscribe, clean }]
+const [ref, { start, stop, abort, subscribe, unsubscribe, clean, isRecording }]
 ```
 
 | Args        | Type | Description                                          |
@@ -328,6 +328,7 @@ const [ref, { start, stop, abort, subscribe, unsubscribe, clean }]
 | subscribe   | func | Function to subscribe to recognition events          |
 | unsubscribe | func | Function to unsubscribe to recognition events        |
 | clean       | func | Function to clean subscription to recognition events |
+| isRecording | bool | Reactive flag mirroring whether a session is active. `true` between `start()` and the next `end`/`error` event. Updated optimistically on `start()` so the UI re-renders at click time. |
 
 #### Cancelling a start in flight
 

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ const [ref, { start, stop, abort, subscribe, unsubscribe, clean, isRecording }]
 | Args        | Type | Description                                          |
 | ----------- | ---- | ---------------------------------------------------- |
 | ref         | Ref  | React ref to the underlying `@untemps/vocal` instance |
-| start       | func | Function to start the recognition. Accepts an optional `{ signal }` argument — an `AbortSignal` propagated to the underlying `start()` call. |
+| start       | func | Function to start the recognition. Accepts an optional `{ signal }` argument — an `AbortSignal` propagated to the underlying `start()` call. Returns the underlying `vocal.start()` promise (resolves once the session starts, rejects on microphone/permission errors). |
 | stop        | func | Function to stop the recognition                     |
 | abort       | func | Function to abort the recognition                    |
 | subscribe   | func | Function to subscribe to recognition events          |

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
 	"files": [
 		"dist/index.js",
 		"dist/index.es.js",
-		"dist/index.umd.js",
 		"CHANGELOG.md"
 	],
 	"main": "dist/index.js",
@@ -101,10 +100,6 @@
 						{
 							"path": "dist/index.es.js",
 							"label": "ES distribution"
-						},
-						{
-							"path": "dist/index.umd.js",
-							"label": "UMD distribution"
 						}
 					]
 				}

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		}
 	},
 	"dependencies": {
-		"@untemps/vocal": "^1.3.0"
+		"@untemps/vocal": "^2.0.1"
 	},
 	"release": {
 		"branches": [

--- a/src/components/Vocal.jsx
+++ b/src/components/Vocal.jsx
@@ -8,10 +8,11 @@ import useCommands from '../hooks/useCommands'
 
 import Icon from './Icon'
 
-const tryMatchCommand = (segmentData, trigger) => {
-	for (const { alternatives } of segmentData) {
-		for (const a of alternatives) {
-			if (trigger(a) !== null) return
+const tryMatchCommand = (results, trigger) => {
+	if (!results) return
+	for (const segment of results) {
+		for (const alt of segment) {
+			if (trigger(alt.transcript ?? '') !== null) return
 		}
 	}
 }
@@ -108,31 +109,17 @@ const Vocal = ({
 	)
 
 	const _onResult = useCallback(
-		(event) => {
-			const segmentData = Array.from(event?.results ?? [], (segment) => {
-				let best = { confidence: -Infinity, transcript: '' }
-				const alternatives = []
-				for (let j = 0; j < segment.length; j++) {
-					const alt = segment[j]
-					alternatives.push(alt.transcript ?? '')
-					if (alt.confidence === undefined || alt.confidence > best.confidence) {
-						best = alt
-					}
-				}
-				return { best: best.transcript ?? '', alternatives }
-			})
-			const transcript = segmentData.map((s) => s.best).join('')
-
+		(event, bestAlternative) => {
 			stopTimer()
 			if (continuousRef.current) {
 				// Accumulate — onResult fires once at session end, not after each segment
-				accumulatedRef.current.transcript = transcript
+				accumulatedRef.current.transcript = bestAlternative
 				accumulatedRef.current.event = event
 				if (silenceTimeoutRef.current > 0) startSilenceTimer()
 			} else {
-				tryMatchCommand(segmentData, triggerCommandRef.current)
+				tryMatchCommand(event?.results, triggerCommandRef.current)
 				stopRecognition()
-				propsRef.current.onResult?.(transcript, event)
+				propsRef.current.onResult?.(bestAlternative, event)
 			}
 		},
 		[stopTimer, startSilenceTimer, stopRecognition]

--- a/src/components/Vocal.jsx
+++ b/src/components/Vocal.jsx
@@ -9,7 +9,6 @@ import useCommands from '../hooks/useCommands'
 import Icon from './Icon'
 
 const tryMatchCommand = (results, trigger) => {
-	if (!results) return
 	for (const segment of results) {
 		for (const alt of segment) {
 			if (trigger(alt.transcript ?? '') !== null) return
@@ -118,7 +117,7 @@ const Vocal = ({
 			// no need to accumulate. tryMatchCommand is skipped in continuous because commands are
 			// intentionally not evaluated against the full session transcript.
 			if (!continuousRef.current) {
-				tryMatchCommand(event?.results, triggerCommandRef.current)
+				tryMatchCommand(event?.results ?? [], triggerCommandRef.current)
 				stopRecognition()
 			}
 			propsRef.current.onResult?.(bestAlternative, event)

--- a/src/components/Vocal.jsx
+++ b/src/components/Vocal.jsx
@@ -1,5 +1,5 @@
 import React, { cloneElement, isValidElement, useCallback, useMemo, useRef, useState } from 'react'
-import { Vocal as SpeechRecognitionWrapper } from '@untemps/vocal'
+import { isSupported } from '@untemps/vocal'
 import { isFunction } from '@untemps/utils/function/isFunction'
 
 import useVocal from '../hooks/useVocal'
@@ -241,7 +241,7 @@ const Vocal = ({
 	)
 
 	const _renderChildren = () => {
-		if (SpeechRecognitionWrapper.isSupported) {
+		if (isSupported()) {
 			if (isFunction(children)) {
 				return children(startRecognition, stopRecognition, isListening)
 			} else if (isValidElement(children)) {

--- a/src/components/Vocal.jsx
+++ b/src/components/Vocal.jsx
@@ -1,5 +1,5 @@
 import React, { cloneElement, isValidElement, useCallback, useMemo, useRef } from 'react'
-import { isSupported } from '@untemps/vocal'
+import { isSupported as isSupportedFn } from '@untemps/vocal'
 import { isFunction } from '@untemps/utils/function/isFunction'
 
 import useVocal from '../hooks/useVocal'
@@ -42,6 +42,7 @@ const Vocal = ({
 	__rsInstance,
 }) => {
 	const buttonRef = useRef(null)
+	const isSupported = useMemo(() => isSupportedFn(), [])
 
 	const [, { start, stop, subscribe, unsubscribe, isRecording: isListening }] = useVocal(
 		lang,
@@ -231,7 +232,7 @@ const Vocal = ({
 	)
 
 	const _renderChildren = () => {
-		if (isSupported()) {
+		if (isSupported) {
 			if (isFunction(children)) {
 				return children(startRecognition, stopRecognition, isListening)
 			} else if (isValidElement(children)) {

--- a/src/components/Vocal.jsx
+++ b/src/components/Vocal.jsx
@@ -37,6 +37,7 @@ const Vocal = ({
 	onResult = null,
 	onError = null,
 	onNoMatch = null,
+	signal = null,
 	__rsInstance,
 }) => {
 	const buttonRef = useRef(null)
@@ -194,11 +195,11 @@ const Vocal = ({
 			stopSilenceTimer()
 			setIsListening(true)
 			Object.entries(HANDLERS).forEach(([event, fn]) => subscribe(event, fn))
-			start()
+			start({ signal })
 		} catch (error) {
 			_onError(error)
 		}
-	}, [HANDLERS, subscribe, start, stopSilenceTimer, _onError])
+	}, [HANDLERS, subscribe, start, stopSilenceTimer, _onError, signal])
 
 	const _onFocus = () => {
 		if (!className && outlineStyle) {

--- a/src/components/Vocal.jsx
+++ b/src/components/Vocal.jsx
@@ -63,6 +63,7 @@ const Vocal = ({
 
 	const unsubscribeAllRef = useRef(null)
 	const onEndRef = useRef(null)
+	const isEndingRef = useRef(false)
 
 	const silenceTimeoutRef = useRef(silenceTimeout)
 	silenceTimeoutRef.current = silenceTimeout
@@ -143,12 +144,18 @@ const Vocal = ({
 
 	const _onEnd = useCallback(
 		(e) => {
+			// Guard against re-entry: when a timer (timeout/silenceTimeout) fires _onEnd,
+			// stopRecognition() calls vocal.stop() which dispatches the 'end' event, which
+			// would re-enter _onEnd and double-fire onEnd.
+			if (isEndingRef.current) return
+			isEndingRef.current = true
 			stopTimer()
 			stopSilenceTimer()
 			try {
 				stopRecognition()
 				unsubscribeAllRef.current?.()
 			} finally {
+				isEndingRef.current = false
 				propsRef.current.onEnd?.(e)
 			}
 		},

--- a/src/components/Vocal.jsx
+++ b/src/components/Vocal.jsx
@@ -58,9 +58,6 @@ const Vocal = ({
 	const continuousRef = useRef(continuous)
 	continuousRef.current = continuous
 
-	// In continuous mode, transcript accumulates across segments and is only emitted via onResult on session end
-	const accumulatedRef = useRef({ transcript: '', event: null })
-
 	const triggerCommandRef = useRef(triggerCommand)
 	triggerCommandRef.current = triggerCommand
 
@@ -103,26 +100,28 @@ const Vocal = ({
 	const _onSpeechEnd = useCallback(
 		(e) => {
 			startTimer()
+			// silenceTimeout fires stop() after N ms of silence following speech in continuous mode.
+			// Anchored on speechend because vocal 2.x intercepts intermediate result events in continuous mode,
+			// so _onResult only runs once on the aggregated end-of-session event.
+			if (continuousRef.current && silenceTimeoutRef.current > 0) startSilenceTimer()
 			propsRef.current.onSpeechEnd?.(e)
 		},
-		[startTimer]
+		[startTimer, startSilenceTimer]
 	)
 
 	const _onResult = useCallback(
 		(event, bestAlternative) => {
 			stopTimer()
-			if (continuousRef.current) {
-				// Accumulate — onResult fires once at session end, not after each segment
-				accumulatedRef.current.transcript = bestAlternative
-				accumulatedRef.current.event = event
-				if (silenceTimeoutRef.current > 0) startSilenceTimer()
-			} else {
+			// In continuous mode, vocal 2.x emits a single aggregated synthetic event just before 'end' —
+			// no need to accumulate. tryMatchCommand is skipped in continuous because commands are
+			// intentionally not evaluated against the full session transcript.
+			if (!continuousRef.current) {
 				tryMatchCommand(event?.results, triggerCommandRef.current)
 				stopRecognition()
-				propsRef.current.onResult?.(bestAlternative, event)
 			}
+			propsRef.current.onResult?.(bestAlternative, event)
 		},
-		[stopTimer, startSilenceTimer, stopRecognition]
+		[stopTimer, stopRecognition]
 	)
 
 	const _onError = useCallback(
@@ -149,11 +148,6 @@ const Vocal = ({
 			try {
 				stopRecognition()
 				unsubscribeAllRef.current?.()
-				if (continuousRef.current && accumulatedRef.current.transcript) {
-					propsRef.current.onResult?.(accumulatedRef.current.transcript, accumulatedRef.current.event)
-					accumulatedRef.current.transcript = ''
-					accumulatedRef.current.event = null
-				}
 			} finally {
 				propsRef.current.onEnd?.(e)
 			}
@@ -181,8 +175,6 @@ const Vocal = ({
 
 	const startRecognition = useCallback(() => {
 		try {
-			accumulatedRef.current.transcript = ''
-			accumulatedRef.current.event = null
 			stopSilenceTimer()
 			Object.entries(HANDLERS).forEach(([event, fn]) => subscribe(event, fn))
 			start({ signal })

--- a/src/components/Vocal.jsx
+++ b/src/components/Vocal.jsx
@@ -185,7 +185,9 @@ const Vocal = ({
 		try {
 			stopSilenceTimer()
 			Object.entries(HANDLERS).forEach(([event, fn]) => subscribe(event, fn))
-			start({ signal })
+			// vocal 2.x rejects on microphone/permission errors — catch the async
+			// rejection so it doesn't surface as an UnhandledPromiseRejection.
+			start({ signal })?.catch?.(_onError)
 		} catch (error) {
 			_onError(error)
 		}

--- a/src/components/Vocal.jsx
+++ b/src/components/Vocal.jsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, isValidElement, useCallback, useMemo, useRef, useState } from 'react'
+import React, { cloneElement, isValidElement, useCallback, useMemo, useRef } from 'react'
 import { isSupported } from '@untemps/vocal'
 import { isFunction } from '@untemps/utils/function/isFunction'
 
@@ -41,9 +41,14 @@ const Vocal = ({
 	__rsInstance,
 }) => {
 	const buttonRef = useRef(null)
-	const [isListening, setIsListening] = useState(false)
 
-	const [, { start, stop, subscribe, unsubscribe }] = useVocal(lang, grammars, maxAlternatives, continuous, __rsInstance)
+	const [, { start, stop, subscribe, unsubscribe, isRecording: isListening }] = useVocal(
+		lang,
+		grammars,
+		maxAlternatives,
+		continuous,
+		__rsInstance
+	)
 	const triggerCommand = useCommands(commands, precision)
 
 	const propsRef = useRef({})
@@ -71,7 +76,6 @@ const Vocal = ({
 
 	const stopRecognition = useCallback(() => {
 		try {
-			setIsListening(false)
 			stop()
 		} catch (error) {
 			propsRef.current.onError?.(error)
@@ -193,7 +197,6 @@ const Vocal = ({
 			accumulatedRef.current.transcript = ''
 			accumulatedRef.current.event = null
 			stopSilenceTimer()
-			setIsListening(true)
 			Object.entries(HANDLERS).forEach(([event, fn]) => subscribe(event, fn))
 			start({ signal })
 		} catch (error) {

--- a/src/components/__tests__/Vocal.test.jsx
+++ b/src/components/__tests__/Vocal.test.jsx
@@ -731,7 +731,8 @@ describe('Vocal', () => {
 				vi.advanceTimersByTime(5000)
 			})
 
-			expect(onEnd).toHaveBeenCalled()
+			expect(onEnd).toHaveBeenCalledTimes(1)
+			expect(onResult).toHaveBeenCalledTimes(1)
 			expect(onResult).toHaveBeenCalledWith('Hello', expect.anything())
 			vi.useRealTimers()
 		})

--- a/src/components/__tests__/Vocal.test.jsx
+++ b/src/components/__tests__/Vocal.test.jsx
@@ -609,6 +609,20 @@ describe('Vocal', () => {
 		})
 	})
 
+	it('does not dispatch the start event when the signal prop is already aborted', async () => {
+		const onStart = vi.fn()
+		const controller = new AbortController()
+		controller.abort()
+		const { getByTestId } = render(getInstance({ onStart, signal: controller.signal }))
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+			await new Promise((r) => setTimeout(r, 50))
+		})
+
+		expect(onStart).not.toHaveBeenCalled()
+	})
+
 	it('calls onEnd via the end event when stop is asynchronous', async () => {
 		const onEnd = vi.fn()
 		const recognition = createVocal()

--- a/src/components/__tests__/Vocal.test.jsx
+++ b/src/components/__tests__/Vocal.test.jsx
@@ -755,6 +755,7 @@ describe('Vocal', () => {
 				recognition.say('hello')
 			})
 
+			expect(onResult).toHaveBeenCalledTimes(1)
 			expect(onResult).toHaveBeenCalledWith('hello', expect.anything())
 		})
 	})

--- a/src/components/__tests__/Vocal.test.jsx
+++ b/src/components/__tests__/Vocal.test.jsx
@@ -1,16 +1,15 @@
 import React from 'react'
 import { waitFor } from '@testing-library/dom'
 import { act, fireEvent, render } from '@testing-library/react'
-import { createVocal, isSupported } from '@untemps/vocal'
+import { isSupported } from '@untemps/vocal'
 
 import Vocal from '../Vocal'
+import { createMockVocal } from './createMockVocal'
 
 vi.mock('@untemps/vocal', async (importOriginal) => {
 	const actual = await importOriginal()
 	return { ...actual, isSupported: vi.fn(actual.isSupported) }
 })
-
-const getSr = () => globalThis.__getSpeechRecognition()
 
 const defaultProps = {}
 const getInstance = (props = {}, children = null) => (
@@ -149,7 +148,7 @@ describe('Vocal', () => {
 
 	it('responds to command', async () => {
 		const callback = vi.fn()
-		const recognition = createVocal()
+		const recognition = createMockVocal()
 		const commands = { foo: callback }
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, commands }))
 
@@ -163,7 +162,7 @@ describe('Vocal', () => {
 
 			await waitFor(() => flag)
 
-			getSr().say('Foo')
+			recognition.say('Foo')
 			await waitFor(() => expect(callback).toHaveBeenCalledWith('Foo', 'foo'))
 		})
 	})
@@ -179,7 +178,7 @@ describe('Vocal', () => {
 
 	it('triggers onResult handler', async () => {
 		const onResult = vi.fn()
-		const recognition = createVocal()
+		const recognition = createMockVocal()
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onResult }))
 
 		let flag = false
@@ -192,14 +191,14 @@ describe('Vocal', () => {
 
 			await waitFor(() => flag)
 
-			getSr().say('Foo')
+			recognition.say('Foo')
 			await waitFor(() => expect(onResult).toHaveBeenCalledWith('Foo', expect.anything()))
 		})
 	})
 
 	it('triggers onNoMatch handler', async () => {
 		const onNoMatch = vi.fn()
-		const recognition = createVocal()
+		const recognition = createMockVocal()
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onNoMatch }))
 
 		let flag = false
@@ -212,14 +211,14 @@ describe('Vocal', () => {
 
 			await waitFor(() => flag)
 
-			getSr().say(null)
+			recognition.say(null)
 			await waitFor(() => expect(onNoMatch).toHaveBeenCalled())
 		})
 	})
 
 	it('triggers onSpeechStart handler', async () => {
 		const onSpeechStart = vi.fn()
-		const recognition = createVocal()
+		const recognition = createMockVocal()
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onSpeechStart }))
 
 		let flag = false
@@ -232,14 +231,14 @@ describe('Vocal', () => {
 
 			await waitFor(() => flag)
 
-			getSr().say('Foo')
+			recognition.say('Foo')
 			await waitFor(() => expect(onSpeechStart).toHaveBeenCalled())
 		})
 	})
 
 	it('triggers onSpeechEnd handler', async () => {
 		const onSpeechEnd = vi.fn()
-		const recognition = createVocal()
+		const recognition = createMockVocal()
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onSpeechEnd }))
 
 		let flag = false
@@ -252,7 +251,7 @@ describe('Vocal', () => {
 
 			await waitFor(() => flag)
 
-			getSr().say('Foo')
+			recognition.say('Foo')
 			await waitFor(() => expect(onSpeechEnd).toHaveBeenCalled())
 		})
 	})
@@ -269,7 +268,7 @@ describe('Vocal', () => {
 
 	it('triggers onEnd handler after speech', async () => {
 		const onEnd = vi.fn()
-		const recognition = createVocal()
+		const recognition = createMockVocal()
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onEnd }))
 
 		let flag = false
@@ -282,7 +281,7 @@ describe('Vocal', () => {
 
 			await waitFor(() => flag)
 
-			getSr().say('Foo')
+			recognition.say('Foo')
 			await waitFor(() => expect(onEnd).toHaveBeenCalled())
 		})
 	})
@@ -290,7 +289,7 @@ describe('Vocal', () => {
 	it('calls the updated onEnd prop after a re-render during an active session', async () => {
 		const onEndV1 = vi.fn()
 		const onEndV2 = vi.fn()
-		const recognition = createVocal()
+		const recognition = createMockVocal()
 		const { getByTestId, rerender } = render(getInstance({ __rsInstance: recognition, onEnd: onEndV1 }))
 
 		await act(async () => {
@@ -303,7 +302,7 @@ describe('Vocal', () => {
 		})
 
 		await act(async () => {
-			getSr().say('Foo')
+			recognition.say('Foo')
 			await waitFor(() => expect(onEndV2).toHaveBeenCalled())
 		})
 
@@ -312,7 +311,7 @@ describe('Vocal', () => {
 
 	it('resets to idle after a re-render during an active session', async () => {
 		const onEnd = vi.fn()
-		const recognition = createVocal()
+		const recognition = createMockVocal()
 		const { getByTestId, rerender } = render(getInstance({ __rsInstance: recognition, onEnd }))
 
 		await act(async () => {
@@ -325,7 +324,7 @@ describe('Vocal', () => {
 		})
 
 		await act(async () => {
-			getSr().say('Foo')
+			recognition.say('Foo')
 			await waitFor(() => expect(onEnd).toHaveBeenCalled())
 		})
 
@@ -335,7 +334,7 @@ describe('Vocal', () => {
 	it('calls the updated onResult prop after a re-render during an active session', async () => {
 		const onResultV1 = vi.fn()
 		const onResultV2 = vi.fn()
-		const recognition = createVocal()
+		const recognition = createMockVocal()
 		const { getByTestId, rerender } = render(getInstance({ __rsInstance: recognition, onResult: onResultV1 }))
 
 		await act(async () => {
@@ -348,7 +347,7 @@ describe('Vocal', () => {
 		})
 
 		await act(async () => {
-			getSr().say('Foo')
+			recognition.say('Foo')
 			await waitFor(() => expect(onResultV2).toHaveBeenCalledWith('Foo', expect.anything()))
 		})
 
@@ -358,7 +357,7 @@ describe('Vocal', () => {
 	it('calls the updated onSpeechStart prop after a re-render during an active session', async () => {
 		const onSpeechStartV1 = vi.fn()
 		const onSpeechStartV2 = vi.fn()
-		const recognition = createVocal()
+		const recognition = createMockVocal()
 		const { getByTestId, rerender } = render(getInstance({ __rsInstance: recognition, onSpeechStart: onSpeechStartV1 }))
 
 		await act(async () => {
@@ -371,7 +370,7 @@ describe('Vocal', () => {
 		})
 
 		await act(async () => {
-			getSr().say('Foo')
+			recognition.say('Foo')
 			await waitFor(() => expect(onSpeechStartV2).toHaveBeenCalled())
 		})
 
@@ -381,7 +380,7 @@ describe('Vocal', () => {
 	it('calls the updated onSpeechEnd prop after a re-render during an active session', async () => {
 		const onSpeechEndV1 = vi.fn()
 		const onSpeechEndV2 = vi.fn()
-		const recognition = createVocal()
+		const recognition = createMockVocal()
 		const { getByTestId, rerender } = render(getInstance({ __rsInstance: recognition, onSpeechEnd: onSpeechEndV1 }))
 
 		await act(async () => {
@@ -394,7 +393,7 @@ describe('Vocal', () => {
 		})
 
 		await act(async () => {
-			getSr().say('Foo')
+			recognition.say('Foo')
 			await waitFor(() => expect(onSpeechEndV2).toHaveBeenCalled())
 		})
 
@@ -404,7 +403,7 @@ describe('Vocal', () => {
 	it('calls the updated onNoMatch prop after a re-render during an active session', async () => {
 		const onNoMatchV1 = vi.fn()
 		const onNoMatchV2 = vi.fn()
-		const recognition = createVocal()
+		const recognition = createMockVocal()
 		const { getByTestId, rerender } = render(getInstance({ __rsInstance: recognition, onNoMatch: onNoMatchV1 }))
 
 		await act(async () => {
@@ -417,7 +416,7 @@ describe('Vocal', () => {
 		})
 
 		await act(async () => {
-			getSr().say(null)
+			recognition.say(null)
 			await waitFor(() => expect(onNoMatchV2).toHaveBeenCalled())
 		})
 
@@ -427,7 +426,7 @@ describe('Vocal', () => {
 	it('calls the updated onError prop after a re-render during an active session', async () => {
 		const onErrorV1 = vi.fn()
 		const onErrorV2 = vi.fn()
-		const recognition = createVocal()
+		const recognition = createMockVocal()
 		const { getByTestId, rerender } = render(getInstance({ __rsInstance: recognition, onError: onErrorV1 }))
 
 		await act(async () => {
@@ -440,7 +439,7 @@ describe('Vocal', () => {
 		})
 
 		await act(async () => {
-			getSr().error(new Error('mic failure'))
+			recognition.error(new Error('mic failure'))
 			await waitFor(() => expect(onErrorV2).toHaveBeenCalled())
 		})
 
@@ -449,13 +448,13 @@ describe('Vocal', () => {
 
 	it('triggers command matched on first segment in multi-segment result', async () => {
 		const callback = vi.fn()
-		const recognition = createVocal()
+		const recognition = createMockVocal()
 		const commands = { hello: callback }
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, commands }))
 
 		await act(async () => {
 			fireEvent.click(getByTestId('__vocal-root__'))
-			getSr().say([
+			recognition.say([
 				[{ transcript: 'hello', confidence: 0.9 }],
 				[{ transcript: 'world', confidence: 0.8 }],
 			])
@@ -465,13 +464,13 @@ describe('Vocal', () => {
 
 	it('triggers command matched on second segment in multi-segment result', async () => {
 		const callback = vi.fn()
-		const recognition = createVocal()
+		const recognition = createMockVocal()
 		const commands = { world: callback }
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, commands }))
 
 		await act(async () => {
 			fireEvent.click(getByTestId('__vocal-root__'))
-			getSr().say([
+			recognition.say([
 				[{ transcript: 'hello', confidence: 0.9 }],
 				[{ transcript: 'world', confidence: 0.8 }],
 			])
@@ -481,13 +480,13 @@ describe('Vocal', () => {
 
 	it('does not trigger command when no segment matches', async () => {
 		const callback = vi.fn()
-		const recognition = createVocal()
+		const recognition = createMockVocal()
 		const commands = { foo: callback }
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, commands }))
 
 		await act(async () => {
 			fireEvent.click(getByTestId('__vocal-root__'))
-			getSr().say([
+			recognition.say([
 				[{ transcript: 'hello', confidence: 0.9 }],
 				[{ transcript: 'world', confidence: 0.8 }],
 			])
@@ -500,13 +499,13 @@ describe('Vocal', () => {
 	it('fires only the first matching command when multiple segments each match a different command', async () => {
 		const callbackHello = vi.fn()
 		const callbackWorld = vi.fn()
-		const recognition = createVocal()
+		const recognition = createMockVocal()
 		const commands = { hello: callbackHello, world: callbackWorld }
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, commands }))
 
 		await act(async () => {
 			fireEvent.click(getByTestId('__vocal-root__'))
-			getSr().say([
+			recognition.say([
 				[{ transcript: 'hello', confidence: 0.9 }],
 				[{ transcript: 'world', confidence: 0.8 }],
 			])
@@ -518,12 +517,12 @@ describe('Vocal', () => {
 
 	it('returns the most confident alternative as the onResult transcript', async () => {
 		const onResult = vi.fn()
-		const recognition = createVocal()
+		const recognition = createMockVocal()
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onResult }))
 
 		await act(async () => {
 			fireEvent.click(getByTestId('__vocal-root__'))
-			getSr().say([[
+			recognition.say([[
 				{ transcript: 'bar', confidence: 0.4 },
 				{ transcript: 'foo', confidence: 0.9 },
 				{ transcript: 'baz', confidence: 0.1 },
@@ -534,27 +533,27 @@ describe('Vocal', () => {
 
 	it('triggers command matched on a word within a multi-word segment', async () => {
 		const callback = vi.fn()
-		const recognition = createVocal()
+		const recognition = createMockVocal()
 		const commands = { rouge: callback }
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, commands }))
 
 		await act(async () => {
 			fireEvent.click(getByTestId('__vocal-root__'))
-			getSr().say([[{ transcript: 'je veux du rouge', confidence: 0.9 }]])
+			recognition.say([[{ transcript: 'je veux du rouge', confidence: 0.9 }]])
 			await waitFor(() => expect(callback).toHaveBeenCalledWith('rouge', 'rouge'))
 		})
 	})
 
 	it('triggers command matched on a secondary alternative (homophone)', async () => {
 		const callback = vi.fn()
-		const recognition = createVocal()
+		const recognition = createMockVocal()
 		const commands = { vert: callback }
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, commands, maxAlternatives: 3 }))
 
 		await act(async () => {
 			fireEvent.click(getByTestId('__vocal-root__'))
 			// Primary alternative is the homophone; secondary is the correct word
-			getSr().say([[
+			recognition.say([[
 				{ transcript: 'verre', confidence: 0.9 },
 				{ transcript: 'vert', confidence: 0.7 },
 			]])
@@ -564,13 +563,13 @@ describe('Vocal', () => {
 
 	it('passes the most confident transcript to onResult even when command matches a secondary alternative', async () => {
 		const onResult = vi.fn()
-		const recognition = createVocal()
+		const recognition = createMockVocal()
 		const commands = { vert: vi.fn() }
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, commands, onResult, maxAlternatives: 3 }))
 
 		await act(async () => {
 			fireEvent.click(getByTestId('__vocal-root__'))
-			getSr().say([[
+			recognition.say([[
 				{ transcript: 'verre', confidence: 0.9 },
 				{ transcript: 'vert', confidence: 0.7 },
 			]])
@@ -594,19 +593,19 @@ describe('Vocal', () => {
 
 	it('calls onEnd via the end event when stop is asynchronous', async () => {
 		const onEnd = vi.fn()
-		const recognition = createVocal()
+		const recognition = createMockVocal()
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onEnd }))
 
 		// Simulate async stop: override stop() so the end event does not fire immediately
-		getSr().stop = vi.fn()
+		recognition.stop.mockImplementation(() => {})
 
 		await act(async () => {
 			fireEvent.click(getByTestId('__vocal-root__'))
-			getSr().say('Foo')
+			recognition.say('Foo')
 			// stopRecognition was called but end has not fired yet — onEnd must not be called
 			expect(onEnd).not.toHaveBeenCalled()
 			// Browser fires end asynchronously after recognition stops
-			getSr().end()
+			recognition.end()
 			await waitFor(() => expect(onEnd).toHaveBeenCalled())
 		})
 	})
@@ -614,7 +613,7 @@ describe('Vocal', () => {
 	describe('Continuous sessions', () => {
 		it('keeps session active after first result without firing onResult', async () => {
 			const onResult = vi.fn()
-			const recognition = createVocal({ continuous: true })
+			const recognition = createMockVocal({ continuous: true })
 			const { getByTestId } = render(getInstance({ __rsInstance: recognition, onResult, continuous: true }))
 
 			await act(async () => {
@@ -622,7 +621,7 @@ describe('Vocal', () => {
 			})
 
 			await act(async () => {
-				getSr().say('Foo')
+				recognition.say('Foo')
 			})
 
 			expect(onResult).not.toHaveBeenCalled()
@@ -634,7 +633,7 @@ describe('Vocal', () => {
 			const onEnd = vi.fn()
 			// Vocal must be created with continuous: true so its internal listeners
 			// intercept intermediate results and emit a single aggregated event on stop.
-			const recognition = createVocal({ continuous: true })
+			const recognition = createMockVocal({ continuous: true })
 			const { getByTestId } = render(
 				getInstance({ __rsInstance: recognition, onResult, onEnd, continuous: true })
 			)
@@ -644,11 +643,11 @@ describe('Vocal', () => {
 			})
 
 			await act(async () => {
-				getSr().say('Hello')
+				recognition.say('Hello')
 			})
 
 			await act(async () => {
-				getSr().say('world')
+				recognition.say('world')
 			})
 
 			expect(onResult).not.toHaveBeenCalled()
@@ -664,7 +663,7 @@ describe('Vocal', () => {
 
 		it('stops session on explicit button click while listening', async () => {
 			const onEnd = vi.fn()
-			const recognition = createVocal({ continuous: true })
+			const recognition = createMockVocal({ continuous: true })
 			const { getByTestId } = render(getInstance({ __rsInstance: recognition, onEnd, continuous: true }))
 
 			await act(async () => {
@@ -672,7 +671,7 @@ describe('Vocal', () => {
 			})
 
 			await act(async () => {
-				getSr().say('Foo')
+				recognition.say('Foo')
 				await waitFor(() => expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-pressed', 'true'))
 			})
 
@@ -687,7 +686,7 @@ describe('Vocal', () => {
 		it('does not evaluate commands in continuous mode', async () => {
 			const commandFn = vi.fn()
 			const onEnd = vi.fn()
-			const recognition = createVocal({ continuous: true })
+			const recognition = createMockVocal({ continuous: true })
 			const { getByTestId } = render(
 				getInstance({ __rsInstance: recognition, commands: { rouge: commandFn }, onEnd, continuous: true })
 			)
@@ -697,7 +696,7 @@ describe('Vocal', () => {
 			})
 
 			await act(async () => {
-				getSr().say('rouge')
+				recognition.say('rouge')
 				await waitFor(() => expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-pressed', 'true'))
 			})
 
@@ -713,7 +712,7 @@ describe('Vocal', () => {
 			vi.useFakeTimers()
 			const onEnd = vi.fn()
 			const onResult = vi.fn()
-			const recognition = createVocal({ continuous: true })
+			const recognition = createMockVocal({ continuous: true })
 			const { getByTestId } = render(
 				getInstance({ __rsInstance: recognition, onEnd, onResult, continuous: true, silenceTimeout: 5000 })
 			)
@@ -723,7 +722,7 @@ describe('Vocal', () => {
 			})
 
 			act(() => {
-				getSr().say('Hello')
+				recognition.say('Hello')
 			})
 
 			expect(onEnd).not.toHaveBeenCalled()

--- a/src/components/__tests__/Vocal.test.jsx
+++ b/src/components/__tests__/Vocal.test.jsx
@@ -614,7 +614,7 @@ describe('Vocal', () => {
 	describe('Continuous sessions', () => {
 		it('keeps session active after first result without firing onResult', async () => {
 			const onResult = vi.fn()
-			const recognition = createVocal()
+			const recognition = createVocal({ continuous: true })
 			const { getByTestId } = render(getInstance({ __rsInstance: recognition, onResult, continuous: true }))
 
 			await act(async () => {
@@ -664,7 +664,7 @@ describe('Vocal', () => {
 
 		it('stops session on explicit button click while listening', async () => {
 			const onEnd = vi.fn()
-			const recognition = createVocal()
+			const recognition = createVocal({ continuous: true })
 			const { getByTestId } = render(getInstance({ __rsInstance: recognition, onEnd, continuous: true }))
 
 			await act(async () => {
@@ -687,7 +687,7 @@ describe('Vocal', () => {
 		it('does not evaluate commands in continuous mode', async () => {
 			const commandFn = vi.fn()
 			const onEnd = vi.fn()
-			const recognition = createVocal()
+			const recognition = createVocal({ continuous: true })
 			const { getByTestId } = render(
 				getInstance({ __rsInstance: recognition, commands: { rouge: commandFn }, onEnd, continuous: true })
 			)
@@ -713,7 +713,7 @@ describe('Vocal', () => {
 			vi.useFakeTimers()
 			const onEnd = vi.fn()
 			const onResult = vi.fn()
-			const recognition = createVocal()
+			const recognition = createVocal({ continuous: true })
 			const { getByTestId } = render(
 				getInstance({ __rsInstance: recognition, onEnd, onResult, continuous: true, silenceTimeout: 5000 })
 			)

--- a/src/components/__tests__/Vocal.test.jsx
+++ b/src/components/__tests__/Vocal.test.jsx
@@ -1,9 +1,16 @@
 import React from 'react'
 import { waitFor } from '@testing-library/dom'
 import { act, fireEvent, render } from '@testing-library/react'
-import { Vocal as SpeechRecognitionWrapper } from '@untemps/vocal'
+import { createVocal, isSupported } from '@untemps/vocal'
 
 import Vocal from '../Vocal'
+
+vi.mock('@untemps/vocal', async (importOriginal) => {
+	const actual = await importOriginal()
+	return { ...actual, isSupported: vi.fn(actual.isSupported) }
+})
+
+const getSr = () => globalThis.__getSpeechRecognition()
 
 const defaultProps = {}
 const getInstance = (props = {}, children = null) => (
@@ -30,7 +37,7 @@ describe('Vocal', () => {
 	})
 
 	it('renders no children element if SpeechRecognition is not supported', () => {
-		vi.spyOn(SpeechRecognitionWrapper, 'isSupported', 'get').mockReturnValueOnce(false)
+		vi.mocked(isSupported).mockReturnValueOnce(false)
 		const { queryByTestId } = render(getInstance(null, <div data-testid="__vocal-custom-root__" />))
 		expect(queryByTestId('__vocal-root__')).not.toBeInTheDocument()
 		expect(queryByTestId('__vocal-custom-root__')).not.toBeInTheDocument()
@@ -142,12 +149,12 @@ describe('Vocal', () => {
 
 	it('responds to command', async () => {
 		const callback = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const commands = { foo: callback }
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, commands }))
 
 		let flag = false
-		recognition.addEventListener('start', async () => {
+		recognition.on('start', async () => {
 			flag = true
 		})
 
@@ -156,7 +163,7 @@ describe('Vocal', () => {
 
 			await waitFor(() => flag)
 
-			recognition.instance.say('Foo')
+			getSr().say('Foo')
 			await waitFor(() => expect(callback).toHaveBeenCalledWith('Foo', 'foo'))
 		})
 	})
@@ -172,11 +179,11 @@ describe('Vocal', () => {
 
 	it('triggers onResult handler', async () => {
 		const onResult = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onResult }))
 
 		let flag = false
-		recognition.addEventListener('start', async () => {
+		recognition.on('start', async () => {
 			flag = true
 		})
 
@@ -185,18 +192,18 @@ describe('Vocal', () => {
 
 			await waitFor(() => flag)
 
-			recognition.instance.say('Foo')
+			getSr().say('Foo')
 			await waitFor(() => expect(onResult).toHaveBeenCalledWith('Foo', expect.anything()))
 		})
 	})
 
 	it('triggers onNoMatch handler', async () => {
 		const onNoMatch = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onNoMatch }))
 
 		let flag = false
-		recognition.addEventListener('start', async () => {
+		recognition.on('start', async () => {
 			flag = true
 		})
 
@@ -205,18 +212,18 @@ describe('Vocal', () => {
 
 			await waitFor(() => flag)
 
-			recognition.instance.say(null)
+			getSr().say(null)
 			await waitFor(() => expect(onNoMatch).toHaveBeenCalled())
 		})
 	})
 
 	it('triggers onSpeechStart handler', async () => {
 		const onSpeechStart = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onSpeechStart }))
 
 		let flag = false
-		recognition.addEventListener('start', async () => {
+		recognition.on('start', async () => {
 			flag = true
 		})
 
@@ -225,18 +232,18 @@ describe('Vocal', () => {
 
 			await waitFor(() => flag)
 
-			recognition.instance.say('Foo')
+			getSr().say('Foo')
 			await waitFor(() => expect(onSpeechStart).toHaveBeenCalled())
 		})
 	})
 
 	it('triggers onSpeechEnd handler', async () => {
 		const onSpeechEnd = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onSpeechEnd }))
 
 		let flag = false
-		recognition.addEventListener('start', async () => {
+		recognition.on('start', async () => {
 			flag = true
 		})
 
@@ -245,7 +252,7 @@ describe('Vocal', () => {
 
 			await waitFor(() => flag)
 
-			recognition.instance.say('Foo')
+			getSr().say('Foo')
 			await waitFor(() => expect(onSpeechEnd).toHaveBeenCalled())
 		})
 	})
@@ -262,11 +269,11 @@ describe('Vocal', () => {
 
 	it('triggers onEnd handler after speech', async () => {
 		const onEnd = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onEnd }))
 
 		let flag = false
-		recognition.addEventListener('start', async () => {
+		recognition.on('start', async () => {
 			flag = true
 		})
 
@@ -275,7 +282,7 @@ describe('Vocal', () => {
 
 			await waitFor(() => flag)
 
-			recognition.instance.say('Foo')
+			getSr().say('Foo')
 			await waitFor(() => expect(onEnd).toHaveBeenCalled())
 		})
 	})
@@ -283,7 +290,7 @@ describe('Vocal', () => {
 	it('calls the updated onEnd prop after a re-render during an active session', async () => {
 		const onEndV1 = vi.fn()
 		const onEndV2 = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const { getByTestId, rerender } = render(getInstance({ __rsInstance: recognition, onEnd: onEndV1 }))
 
 		await act(async () => {
@@ -296,7 +303,7 @@ describe('Vocal', () => {
 		})
 
 		await act(async () => {
-			recognition.instance.say('Foo')
+			getSr().say('Foo')
 			await waitFor(() => expect(onEndV2).toHaveBeenCalled())
 		})
 
@@ -305,7 +312,7 @@ describe('Vocal', () => {
 
 	it('resets to idle after a re-render during an active session', async () => {
 		const onEnd = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const { getByTestId, rerender } = render(getInstance({ __rsInstance: recognition, onEnd }))
 
 		await act(async () => {
@@ -318,7 +325,7 @@ describe('Vocal', () => {
 		})
 
 		await act(async () => {
-			recognition.instance.say('Foo')
+			getSr().say('Foo')
 			await waitFor(() => expect(onEnd).toHaveBeenCalled())
 		})
 
@@ -328,7 +335,7 @@ describe('Vocal', () => {
 	it('calls the updated onResult prop after a re-render during an active session', async () => {
 		const onResultV1 = vi.fn()
 		const onResultV2 = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const { getByTestId, rerender } = render(getInstance({ __rsInstance: recognition, onResult: onResultV1 }))
 
 		await act(async () => {
@@ -341,7 +348,7 @@ describe('Vocal', () => {
 		})
 
 		await act(async () => {
-			recognition.instance.say('Foo')
+			getSr().say('Foo')
 			await waitFor(() => expect(onResultV2).toHaveBeenCalledWith('Foo', expect.anything()))
 		})
 
@@ -351,7 +358,7 @@ describe('Vocal', () => {
 	it('calls the updated onSpeechStart prop after a re-render during an active session', async () => {
 		const onSpeechStartV1 = vi.fn()
 		const onSpeechStartV2 = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const { getByTestId, rerender } = render(getInstance({ __rsInstance: recognition, onSpeechStart: onSpeechStartV1 }))
 
 		await act(async () => {
@@ -364,7 +371,7 @@ describe('Vocal', () => {
 		})
 
 		await act(async () => {
-			recognition.instance.say('Foo')
+			getSr().say('Foo')
 			await waitFor(() => expect(onSpeechStartV2).toHaveBeenCalled())
 		})
 
@@ -374,7 +381,7 @@ describe('Vocal', () => {
 	it('calls the updated onSpeechEnd prop after a re-render during an active session', async () => {
 		const onSpeechEndV1 = vi.fn()
 		const onSpeechEndV2 = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const { getByTestId, rerender } = render(getInstance({ __rsInstance: recognition, onSpeechEnd: onSpeechEndV1 }))
 
 		await act(async () => {
@@ -387,7 +394,7 @@ describe('Vocal', () => {
 		})
 
 		await act(async () => {
-			recognition.instance.say('Foo')
+			getSr().say('Foo')
 			await waitFor(() => expect(onSpeechEndV2).toHaveBeenCalled())
 		})
 
@@ -397,7 +404,7 @@ describe('Vocal', () => {
 	it('calls the updated onNoMatch prop after a re-render during an active session', async () => {
 		const onNoMatchV1 = vi.fn()
 		const onNoMatchV2 = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const { getByTestId, rerender } = render(getInstance({ __rsInstance: recognition, onNoMatch: onNoMatchV1 }))
 
 		await act(async () => {
@@ -410,7 +417,7 @@ describe('Vocal', () => {
 		})
 
 		await act(async () => {
-			recognition.instance.say(null)
+			getSr().say(null)
 			await waitFor(() => expect(onNoMatchV2).toHaveBeenCalled())
 		})
 
@@ -420,7 +427,7 @@ describe('Vocal', () => {
 	it('calls the updated onError prop after a re-render during an active session', async () => {
 		const onErrorV1 = vi.fn()
 		const onErrorV2 = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const { getByTestId, rerender } = render(getInstance({ __rsInstance: recognition, onError: onErrorV1 }))
 
 		await act(async () => {
@@ -433,7 +440,7 @@ describe('Vocal', () => {
 		})
 
 		await act(async () => {
-			recognition.instance.error(new Error('mic failure'))
+			getSr().error(new Error('mic failure'))
 			await waitFor(() => expect(onErrorV2).toHaveBeenCalled())
 		})
 
@@ -442,13 +449,13 @@ describe('Vocal', () => {
 
 	it('triggers command matched on first segment in multi-segment result', async () => {
 		const callback = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const commands = { hello: callback }
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, commands }))
 
 		await act(async () => {
 			fireEvent.click(getByTestId('__vocal-root__'))
-			recognition.instance.say([
+			getSr().say([
 				[{ transcript: 'hello', confidence: 0.9 }],
 				[{ transcript: 'world', confidence: 0.8 }],
 			])
@@ -458,13 +465,13 @@ describe('Vocal', () => {
 
 	it('triggers command matched on second segment in multi-segment result', async () => {
 		const callback = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const commands = { world: callback }
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, commands }))
 
 		await act(async () => {
 			fireEvent.click(getByTestId('__vocal-root__'))
-			recognition.instance.say([
+			getSr().say([
 				[{ transcript: 'hello', confidence: 0.9 }],
 				[{ transcript: 'world', confidence: 0.8 }],
 			])
@@ -474,13 +481,13 @@ describe('Vocal', () => {
 
 	it('does not trigger command when no segment matches', async () => {
 		const callback = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const commands = { foo: callback }
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, commands }))
 
 		await act(async () => {
 			fireEvent.click(getByTestId('__vocal-root__'))
-			recognition.instance.say([
+			getSr().say([
 				[{ transcript: 'hello', confidence: 0.9 }],
 				[{ transcript: 'world', confidence: 0.8 }],
 			])
@@ -493,13 +500,13 @@ describe('Vocal', () => {
 	it('fires only the first matching command when multiple segments each match a different command', async () => {
 		const callbackHello = vi.fn()
 		const callbackWorld = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const commands = { hello: callbackHello, world: callbackWorld }
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, commands }))
 
 		await act(async () => {
 			fireEvent.click(getByTestId('__vocal-root__'))
-			recognition.instance.say([
+			getSr().say([
 				[{ transcript: 'hello', confidence: 0.9 }],
 				[{ transcript: 'world', confidence: 0.8 }],
 			])
@@ -511,13 +518,13 @@ describe('Vocal', () => {
 
 	it('passes full joined transcript to onResult regardless of command segment matching', async () => {
 		const onResult = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const commands = { hello: vi.fn() }
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, commands, onResult }))
 
 		await act(async () => {
 			fireEvent.click(getByTestId('__vocal-root__'))
-			recognition.instance.say([
+			getSr().say([
 				[{ transcript: 'hello ', confidence: 0.9 }],
 				[{ transcript: 'world', confidence: 0.8 }],
 			])
@@ -527,12 +534,12 @@ describe('Vocal', () => {
 
 	it('returns the most confident alternative as the onResult transcript', async () => {
 		const onResult = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onResult }))
 
 		await act(async () => {
 			fireEvent.click(getByTestId('__vocal-root__'))
-			recognition.instance.say([[
+			getSr().say([[
 				{ transcript: 'bar', confidence: 0.4 },
 				{ transcript: 'foo', confidence: 0.9 },
 				{ transcript: 'baz', confidence: 0.1 },
@@ -543,12 +550,12 @@ describe('Vocal', () => {
 
 	it('joins all segments into the onResult transcript', async () => {
 		const onResult = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onResult }))
 
 		await act(async () => {
 			fireEvent.click(getByTestId('__vocal-root__'))
-			recognition.instance.say([
+			getSr().say([
 				[{ transcript: 'hello ', confidence: 0.9 }],
 				[{ transcript: 'world', confidence: 0.8 }],
 			])
@@ -558,27 +565,27 @@ describe('Vocal', () => {
 
 	it('triggers command matched on a word within a multi-word segment', async () => {
 		const callback = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const commands = { rouge: callback }
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, commands }))
 
 		await act(async () => {
 			fireEvent.click(getByTestId('__vocal-root__'))
-			recognition.instance.say([[{ transcript: 'je veux du rouge', confidence: 0.9 }]])
+			getSr().say([[{ transcript: 'je veux du rouge', confidence: 0.9 }]])
 			await waitFor(() => expect(callback).toHaveBeenCalledWith('rouge', 'rouge'))
 		})
 	})
 
 	it('triggers command matched on a secondary alternative (homophone)', async () => {
 		const callback = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const commands = { vert: callback }
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, commands, maxAlternatives: 3 }))
 
 		await act(async () => {
 			fireEvent.click(getByTestId('__vocal-root__'))
 			// Primary alternative is the homophone; secondary is the correct word
-			recognition.instance.say([[
+			getSr().say([[
 				{ transcript: 'verre', confidence: 0.9 },
 				{ transcript: 'vert', confidence: 0.7 },
 			]])
@@ -588,13 +595,13 @@ describe('Vocal', () => {
 
 	it('passes the most confident transcript to onResult even when command matches a secondary alternative', async () => {
 		const onResult = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const commands = { vert: vi.fn() }
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, commands, onResult, maxAlternatives: 3 }))
 
 		await act(async () => {
 			fireEvent.click(getByTestId('__vocal-root__'))
-			recognition.instance.say([[
+			getSr().say([[
 				{ transcript: 'verre', confidence: 0.9 },
 				{ transcript: 'vert', confidence: 0.7 },
 			]])
@@ -604,19 +611,19 @@ describe('Vocal', () => {
 
 	it('calls onEnd via the end event when stop is asynchronous', async () => {
 		const onEnd = vi.fn()
-		const recognition = new SpeechRecognitionWrapper()
+		const recognition = createVocal()
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onEnd }))
 
 		// Simulate async stop: override stop() so the end event does not fire immediately
-		recognition.instance.stop = vi.fn()
+		getSr().stop = vi.fn()
 
 		await act(async () => {
 			fireEvent.click(getByTestId('__vocal-root__'))
-			recognition.instance.say('Foo')
+			getSr().say('Foo')
 			// stopRecognition was called but end has not fired yet — onEnd must not be called
 			expect(onEnd).not.toHaveBeenCalled()
 			// Browser fires end asynchronously after recognition stops
-			recognition.instance.end()
+			getSr().end()
 			await waitFor(() => expect(onEnd).toHaveBeenCalled())
 		})
 	})
@@ -624,7 +631,7 @@ describe('Vocal', () => {
 	describe('Continuous sessions', () => {
 		it('keeps session active after first result without firing onResult', async () => {
 			const onResult = vi.fn()
-			const recognition = new SpeechRecognitionWrapper()
+			const recognition = createVocal()
 			const { getByTestId } = render(getInstance({ __rsInstance: recognition, onResult, continuous: true }))
 
 			await act(async () => {
@@ -632,7 +639,7 @@ describe('Vocal', () => {
 			})
 
 			await act(async () => {
-				recognition.instance.say('Foo')
+				getSr().say('Foo')
 			})
 
 			expect(onResult).not.toHaveBeenCalled()
@@ -642,7 +649,7 @@ describe('Vocal', () => {
 		it('fires onResult once at session end with full accumulated transcript', async () => {
 			const onResult = vi.fn()
 			const onEnd = vi.fn()
-			const recognition = new SpeechRecognitionWrapper()
+			const recognition = createVocal()
 			const { getByTestId } = render(
 				getInstance({ __rsInstance: recognition, onResult, onEnd, continuous: true })
 			)
@@ -652,11 +659,11 @@ describe('Vocal', () => {
 			})
 
 			await act(async () => {
-				recognition.instance.say('Hello')
+				getSr().say('Hello')
 			})
 
 			await act(async () => {
-				recognition.instance.say(' world')
+				getSr().say(' world')
 			})
 
 			expect(onResult).not.toHaveBeenCalled()
@@ -672,7 +679,7 @@ describe('Vocal', () => {
 
 		it('stops session on explicit button click while listening', async () => {
 			const onEnd = vi.fn()
-			const recognition = new SpeechRecognitionWrapper()
+			const recognition = createVocal()
 			const { getByTestId } = render(getInstance({ __rsInstance: recognition, onEnd, continuous: true }))
 
 			await act(async () => {
@@ -680,7 +687,7 @@ describe('Vocal', () => {
 			})
 
 			await act(async () => {
-				recognition.instance.say('Foo')
+				getSr().say('Foo')
 				await waitFor(() => expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-pressed', 'true'))
 			})
 
@@ -695,7 +702,7 @@ describe('Vocal', () => {
 		it('does not evaluate commands in continuous mode', async () => {
 			const commandFn = vi.fn()
 			const onEnd = vi.fn()
-			const recognition = new SpeechRecognitionWrapper()
+			const recognition = createVocal()
 			const { getByTestId } = render(
 				getInstance({ __rsInstance: recognition, commands: { rouge: commandFn }, onEnd, continuous: true })
 			)
@@ -705,7 +712,7 @@ describe('Vocal', () => {
 			})
 
 			await act(async () => {
-				recognition.instance.say('rouge')
+				getSr().say('rouge')
 				await waitFor(() => expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-pressed', 'true'))
 			})
 
@@ -721,7 +728,7 @@ describe('Vocal', () => {
 			vi.useFakeTimers()
 			const onEnd = vi.fn()
 			const onResult = vi.fn()
-			const recognition = new SpeechRecognitionWrapper()
+			const recognition = createVocal()
 			const { getByTestId } = render(
 				getInstance({ __rsInstance: recognition, onEnd, onResult, continuous: true, silenceTimeout: 5000 })
 			)
@@ -731,7 +738,7 @@ describe('Vocal', () => {
 			})
 
 			act(() => {
-				recognition.instance.say('Hello')
+				getSr().say('Hello')
 			})
 
 			expect(onEnd).not.toHaveBeenCalled()

--- a/src/components/__tests__/Vocal.test.jsx
+++ b/src/components/__tests__/Vocal.test.jsx
@@ -736,5 +736,26 @@ describe('Vocal', () => {
 			expect(onResult).toHaveBeenCalledWith('Hello', expect.anything())
 			vi.useRealTimers()
 		})
+
+		it('does not propagate continuous prop to a pre-built __rsInstance', async () => {
+			// Documents and locks the current contract: <Vocal continuous={true}> does NOT
+			// reconfigure an injected __rsInstance. Callers must create the mock/instance
+			// with continuous: true themselves; otherwise the instance forwards every result
+			// event individually and onResult fires per-utterance instead of once at session
+			// end. Tracked in #136 as part of the __rsInstance redesign.
+			const recognition = createMockVocal() // continuous NOT set
+			const onResult = vi.fn()
+			const { getByTestId } = render(getInstance({ __rsInstance: recognition, onResult, continuous: true }))
+
+			await act(async () => {
+				fireEvent.click(getByTestId('__vocal-root__'))
+			})
+
+			await act(async () => {
+				recognition.say('hello')
+			})
+
+			expect(onResult).toHaveBeenCalledWith('hello', expect.anything())
+		})
 	})
 })

--- a/src/components/__tests__/Vocal.test.jsx
+++ b/src/components/__tests__/Vocal.test.jsx
@@ -516,22 +516,6 @@ describe('Vocal', () => {
 		expect(callbackWorld).not.toHaveBeenCalled()
 	})
 
-	it('passes full joined transcript to onResult regardless of command segment matching', async () => {
-		const onResult = vi.fn()
-		const recognition = createVocal()
-		const commands = { hello: vi.fn() }
-		const { getByTestId } = render(getInstance({ __rsInstance: recognition, commands, onResult }))
-
-		await act(async () => {
-			fireEvent.click(getByTestId('__vocal-root__'))
-			getSr().say([
-				[{ transcript: 'hello ', confidence: 0.9 }],
-				[{ transcript: 'world', confidence: 0.8 }],
-			])
-			await waitFor(() => expect(onResult).toHaveBeenCalledWith('hello world', expect.anything()))
-		})
-	})
-
 	it('returns the most confident alternative as the onResult transcript', async () => {
 		const onResult = vi.fn()
 		const recognition = createVocal()
@@ -545,21 +529,6 @@ describe('Vocal', () => {
 				{ transcript: 'baz', confidence: 0.1 },
 			]])
 			await waitFor(() => expect(onResult).toHaveBeenCalledWith('foo', expect.anything()))
-		})
-	})
-
-	it('joins all segments into the onResult transcript', async () => {
-		const onResult = vi.fn()
-		const recognition = createVocal()
-		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onResult }))
-
-		await act(async () => {
-			fireEvent.click(getByTestId('__vocal-root__'))
-			getSr().say([
-				[{ transcript: 'hello ', confidence: 0.9 }],
-				[{ transcript: 'world', confidence: 0.8 }],
-			])
-			await waitFor(() => expect(onResult).toHaveBeenCalledWith('hello world', expect.anything()))
 		})
 	})
 
@@ -663,7 +632,9 @@ describe('Vocal', () => {
 		it('fires onResult once at session end with full accumulated transcript', async () => {
 			const onResult = vi.fn()
 			const onEnd = vi.fn()
-			const recognition = createVocal()
+			// Vocal must be created with continuous: true so its internal listeners
+			// intercept intermediate results and emit a single aggregated event on stop.
+			const recognition = createVocal({ continuous: true })
 			const { getByTestId } = render(
 				getInstance({ __rsInstance: recognition, onResult, onEnd, continuous: true })
 			)
@@ -677,7 +648,7 @@ describe('Vocal', () => {
 			})
 
 			await act(async () => {
-				getSr().say(' world')
+				getSr().say('world')
 			})
 
 			expect(onResult).not.toHaveBeenCalled()

--- a/src/components/__tests__/createMockVocal.js
+++ b/src/components/__tests__/createMockVocal.js
@@ -1,0 +1,107 @@
+import { vi } from 'vitest'
+
+const buildResultEvent = (segments) => {
+	const evt = new Event('result')
+	evt.resultIndex = 0
+	evt.results = segments
+	return evt
+}
+
+const pickBest = (alternatives) => {
+	let best = alternatives[0]
+	for (const alt of alternatives) {
+		if ((alt.confidence ?? 0) > (best.confidence ?? 0)) best = alt
+	}
+	return best.transcript ?? ''
+}
+
+// Mock VocalInstance for component tests — implements the contract of
+// `createVocal()` from @untemps/vocal 2.x and exposes test helpers
+// (.say, .error, .end, .fire) to simulate the recognition lifecycle
+// without going through the global SpeechRecognition mock.
+export const createMockVocal = (options = {}) => {
+	const handlers = {}
+	let isRecording = false
+	const accumulated = []
+	const continuous = !!options.continuous
+
+	const fire = (type, ...args) => {
+		const cbs = handlers[type]
+		if (!cbs) return
+		for (const cb of cbs.slice()) cb(...args)
+	}
+
+	const instance = {
+		get isRecording() {
+			return isRecording
+		},
+		start: vi.fn(async () => {
+			accumulated.length = 0
+			isRecording = true
+			fire('start', new Event('start'))
+		}),
+		stop: vi.fn(() => {
+			if (continuous && accumulated.length > 0) {
+				const segments = accumulated.slice()
+				accumulated.length = 0
+				const joined = segments
+					.map((seg) => pickBest(seg))
+					.join(' ')
+					.trim()
+				const evt = buildResultEvent(segments)
+				fire('result', evt, joined, [joined])
+			}
+			fire('end', new Event('end'))
+			isRecording = false
+		}),
+		abort: vi.fn(() => {
+			accumulated.length = 0
+			fire('end', new Event('end'))
+			isRecording = false
+		}),
+		on: vi.fn((type, cb) => {
+			if (!handlers[type]) handlers[type] = []
+			handlers[type].push(cb)
+		}),
+		off: vi.fn((type, cb) => {
+			if (!handlers[type]) return
+			if (cb) {
+				handlers[type] = handlers[type].filter((h) => h !== cb)
+				if (handlers[type].length === 0) delete handlers[type]
+			} else {
+				delete handlers[type]
+			}
+		}),
+		cleanup: vi.fn(() => {
+			for (const k of Object.keys(handlers)) delete handlers[k]
+		}),
+		fire,
+		say(input) {
+			fire('speechstart', new Event('speechstart'))
+			const segments = Array.isArray(input) ? input : input ? [[{ transcript: input }]] : null
+			fire('speechend', new Event('speechend'))
+			if (!segments) {
+				fire('nomatch', new Event('nomatch'))
+				return
+			}
+			if (continuous) {
+				// vocal 2.x intercepts intermediate results in continuous mode and accumulates
+				// them internally — they are emitted as a single synthetic event on stop().
+				accumulated.push(...segments)
+				return
+			}
+			const firstSegment = segments[0]
+			const evt = buildResultEvent(segments)
+			const bestAlt = pickBest(firstSegment)
+			const alts = firstSegment.map((a) => a.transcript ?? '')
+			fire('result', evt, bestAlt, alts)
+		},
+		error(err) {
+			fire('error', err)
+		},
+		end() {
+			fire('end', new Event('end'))
+		},
+	}
+	return instance
+}

--- a/src/components/__tests__/createMockVocal.js
+++ b/src/components/__tests__/createMockVocal.js
@@ -19,6 +19,19 @@ const pickBest = (alternatives) => {
 // `createVocal()` from @untemps/vocal 2.x and exposes test helpers
 // (.say, .error, .end, .fire) to simulate the recognition lifecycle
 // without going through the global SpeechRecognition mock.
+//
+// Known limitations vs. the real vocal 2.x:
+// - `start(options)` accepts an options object but ignores `options.signal`.
+//   Tests that need to assert signal pass-through should inspect
+//   `instance.start.mock.calls` directly.
+// - `start` is `async`, so `fire('start', ...)` resolves in a microtask. The
+//   real vocal awaits getUserMediaStream first; the optimistic order in
+//   useVocal is the same in both cases.
+// - The helpers (`say`, `error`, `end`, `fire`) live alongside the public
+//   VocalInstance API on the same object. They are test-only escape hatches;
+//   production code consuming a `VocalInstance` MUST NOT call them. The names
+//   were chosen to be unmistakable (`fire`) or short (`say`, `end`, `error`)
+//   for test readability — keep them off the typed VocalInstance interface.
 export const createMockVocal = (options = {}) => {
 	const handlers = {}
 	let isRecording = false

--- a/src/hooks/__tests__/useVocal.test.js
+++ b/src/hooks/__tests__/useVocal.test.js
@@ -147,6 +147,17 @@ describe('useVocal', () => {
 			expect(mockStart).toHaveBeenCalled()
 		})
 
+		it('forwards start options (signal) to the vocal instance', () => {
+			const controller = new AbortController()
+			const {
+				result: {
+					current: [, { start }],
+				},
+			} = renderHook(() => useVocal())
+			start({ signal: controller.signal })
+			expect(mockStart).toHaveBeenCalledWith({ signal: controller.signal })
+		})
+
 		it('triggers stop function', () => {
 			const {
 				result: {

--- a/src/hooks/__tests__/useVocal.test.js
+++ b/src/hooks/__tests__/useVocal.test.js
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react'
-import { Vocal as SpeechRecognitionWrapper } from '@untemps/vocal'
+import { createVocal, isSupported } from '@untemps/vocal'
 
 import useVocal from '../useVocal'
 
@@ -9,18 +9,13 @@ describe('useVocal', () => {
 	const mockStart = vi.fn()
 	const mockStop = vi.fn()
 	const mockAbort = vi.fn()
-	const mockAddEventListener = vi.fn()
-	const mockRemoveEventListener = vi.fn()
+	const mockOn = vi.fn()
+	const mockOff = vi.fn()
 	const mockCleanup = vi.fn()
-
-	const mockIsSupported = vi.fn()
-	Object.defineProperty(SpeechRecognitionWrapper, 'isSupported', {
-		get: mockIsSupported,
-	})
 
 	describe('with no SpeechRecognition support', () => {
 		beforeAll(() => {
-			mockIsSupported.mockReturnValue(false)
+			vi.mocked(isSupported).mockReturnValue(false)
 		})
 
 		it('cannot create SpeechRecognition instance', () => {
@@ -79,7 +74,7 @@ describe('useVocal', () => {
 				},
 			} = renderHook(() => useVocal())
 			subscribe('foo', vi.fn())
-			expect(mockAddEventListener).not.toHaveBeenCalled()
+			expect(mockOn).not.toHaveBeenCalled()
 		})
 
 		it('not triggers unsubscribe function', () => {
@@ -89,30 +84,28 @@ describe('useVocal', () => {
 				},
 			} = renderHook(() => useVocal())
 			unsubscribe('foo', vi.fn())
-			expect(mockRemoveEventListener).not.toHaveBeenCalled()
+			expect(mockOff).not.toHaveBeenCalled()
 		})
 	})
 
 	describe('with SpeechRecognition support', () => {
 		beforeAll(() => {
-			mockIsSupported.mockReturnValue(true)
+			vi.mocked(isSupported).mockReturnValue(true)
 		})
 
 		beforeEach(() => {
-			SpeechRecognitionWrapper.mockImplementation(function () {
-				return {
-					start: mockStart,
-					stop: mockStop,
-					abort: mockAbort,
-					addEventListener: mockAddEventListener,
-					removeEventListener: mockRemoveEventListener,
-					cleanup: mockCleanup,
-				}
-			})
+			vi.mocked(createVocal).mockImplementation(() => ({
+				start: mockStart,
+				stop: mockStop,
+				abort: mockAbort,
+				on: mockOn,
+				off: mockOff,
+				cleanup: mockCleanup,
+			}))
 		})
 
 		afterEach(() => {
-			SpeechRecognitionWrapper.mockReset()
+			vi.mocked(createVocal).mockReset()
 		})
 
 		it('creates SpeechRecognition instance', () => {
@@ -124,9 +117,9 @@ describe('useVocal', () => {
 			expect(ref.current).toBeDefined()
 		})
 
-		it('passes maxAlternatives to SpeechRecognitionWrapper constructor', () => {
+		it('passes maxAlternatives to createVocal factory', () => {
 			renderHook(() => useVocal('en-US', null, 5))
-			expect(SpeechRecognitionWrapper).toHaveBeenCalledWith({
+			expect(createVocal).toHaveBeenCalledWith({
 				lang: 'en-US',
 				grammars: null,
 				maxAlternatives: 5,
@@ -135,7 +128,7 @@ describe('useVocal', () => {
 		})
 
 		it('uses custom SpeechRecognition instance', () => {
-			const foo = new SpeechRecognitionWrapper()
+			const foo = createVocal()
 			const {
 				result: {
 					current: [ref],
@@ -191,7 +184,7 @@ describe('useVocal', () => {
 				},
 			} = renderHook(() => useVocal())
 			subscribe('foo', vi.fn())
-			expect(mockAddEventListener).toHaveBeenCalled()
+			expect(mockOn).toHaveBeenCalled()
 		})
 
 		it('triggers unsubscribe function', () => {
@@ -201,7 +194,7 @@ describe('useVocal', () => {
 				},
 			} = renderHook(() => useVocal())
 			unsubscribe('foo', vi.fn())
-			expect(mockRemoveEventListener).toHaveBeenCalled()
+			expect(mockOff).toHaveBeenCalled()
 		})
 	})
 })

--- a/src/hooks/__tests__/useVocal.test.js
+++ b/src/hooks/__tests__/useVocal.test.js
@@ -164,6 +164,17 @@ describe('useVocal', () => {
 			expect(mockStart).toHaveBeenCalledWith({ signal: controller.signal })
 		})
 
+		it('returns the promise from the vocal start() call', () => {
+			const startPromise = Promise.resolve()
+			mockStart.mockReturnValue(startPromise)
+			const {
+				result: {
+					current: [, { start }],
+				},
+			} = renderHook(() => useVocal())
+			expect(start()).toBe(startPromise)
+		})
+
 		it('triggers stop function', () => {
 			const {
 				result: {

--- a/src/hooks/__tests__/useVocal.test.js
+++ b/src/hooks/__tests__/useVocal.test.js
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react'
+import { act, renderHook } from '@testing-library/react'
 import { createVocal, isSupported } from '@untemps/vocal'
 
 import useVocal from '../useVocal'
@@ -94,6 +94,12 @@ describe('useVocal', () => {
 		})
 
 		beforeEach(() => {
+			mockStart.mockClear()
+			mockStop.mockClear()
+			mockAbort.mockClear()
+			mockOn.mockClear()
+			mockOff.mockClear()
+			mockCleanup.mockClear()
 			vi.mocked(createVocal).mockImplementation(() => ({
 				start: mockStart,
 				stop: mockStop,
@@ -206,6 +212,42 @@ describe('useVocal', () => {
 			} = renderHook(() => useVocal())
 			unsubscribe('foo', vi.fn())
 			expect(mockOff).toHaveBeenCalled()
+		})
+
+		it('exposes isRecording as false initially', () => {
+			const { result } = renderHook(() => useVocal())
+			expect(result.current[1].isRecording).toBe(false)
+		})
+
+		it('flips isRecording to true on the start event', async () => {
+			const { result } = renderHook(() => useVocal())
+			const startCallback = mockOn.mock.calls.find(([type]) => type === 'start')[1]
+			await act(async () => startCallback(new Event('start')))
+			expect(result.current[1].isRecording).toBe(true)
+		})
+
+		it('flips isRecording back to false on the end event', async () => {
+			const { result } = renderHook(() => useVocal())
+			const startCallback = mockOn.mock.calls.find(([type]) => type === 'start')[1]
+			const endCallback = mockOn.mock.calls.find(([type]) => type === 'end')[1]
+			await act(async () => startCallback(new Event('start')))
+			await act(async () => endCallback(new Event('end')))
+			expect(result.current[1].isRecording).toBe(false)
+		})
+
+		it('flips isRecording back to false on the error event', async () => {
+			const { result } = renderHook(() => useVocal())
+			const startCallback = mockOn.mock.calls.find(([type]) => type === 'start')[1]
+			const errorCallback = mockOn.mock.calls.find(([type]) => type === 'error')[1]
+			await act(async () => startCallback(new Event('start')))
+			await act(async () => errorCallback(new Event('error')))
+			expect(result.current[1].isRecording).toBe(false)
+		})
+
+		it('optimistically flips isRecording to true when start() is called', async () => {
+			const { result } = renderHook(() => useVocal())
+			await act(async () => result.current[1].start())
+			expect(result.current[1].isRecording).toBe(true)
 		})
 	})
 })

--- a/src/hooks/useVocal.js
+++ b/src/hooks/useVocal.js
@@ -14,9 +14,9 @@ const useVocal = (lang = 'en-US', grammars = null, maxAlternatives = 1, continuo
 		}
 	}, [lang, grammars, maxAlternatives, continuous, __rsInstance])
 
-	const start = useCallback(() => {
+	const start = useCallback((options) => {
 		if (ref.current) {
-			ref.current.start()
+			ref.current.start(options)
 		}
 	}, [])
 

--- a/src/hooks/useVocal.js
+++ b/src/hooks/useVocal.js
@@ -1,12 +1,13 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createVocal, isSupported } from '@untemps/vocal'
 
 const useVocal = (lang = 'en-US', grammars = null, maxAlternatives = 1, continuous = false, __rsInstance = null) => {
 	const ref = useRef(null)
 	const [isRecording, setIsRecording] = useState(false)
+	const supported = useMemo(() => isSupported(), [])
 
 	useEffect(() => {
-		if (isSupported()) {
+		if (supported) {
 			const instance = __rsInstance || createVocal({ lang, grammars, maxAlternatives, continuous })
 			ref.current = instance
 
@@ -25,7 +26,7 @@ const useVocal = (lang = 'en-US', grammars = null, maxAlternatives = 1, continuo
 				setIsRecording(false)
 			}
 		}
-	}, [lang, grammars, maxAlternatives, continuous, __rsInstance])
+	}, [lang, grammars, maxAlternatives, continuous, __rsInstance, supported])
 
 	const start = useCallback((options) => {
 		if (ref.current) {

--- a/src/hooks/useVocal.js
+++ b/src/hooks/useVocal.js
@@ -1,21 +1,37 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { createVocal, isSupported } from '@untemps/vocal'
 
 const useVocal = (lang = 'en-US', grammars = null, maxAlternatives = 1, continuous = false, __rsInstance = null) => {
 	const ref = useRef(null)
+	const [isRecording, setIsRecording] = useState(false)
 
 	useEffect(() => {
 		if (isSupported()) {
-			ref.current = __rsInstance || createVocal({ lang, grammars, maxAlternatives, continuous })
+			const instance = __rsInstance || createVocal({ lang, grammars, maxAlternatives, continuous })
+			ref.current = instance
+
+			const handleStart = () => setIsRecording(true)
+			const handleStop = () => setIsRecording(false)
+			instance.on('start', handleStart)
+			instance.on('end', handleStop)
+			instance.on('error', handleStop)
+
 			return () => {
-				ref.current.abort()
-				ref.current.cleanup()
+				instance.off('start', handleStart)
+				instance.off('end', handleStop)
+				instance.off('error', handleStop)
+				instance.abort()
+				instance.cleanup()
+				setIsRecording(false)
 			}
 		}
 	}, [lang, grammars, maxAlternatives, continuous, __rsInstance])
 
 	const start = useCallback((options) => {
 		if (ref.current) {
+			// Optimistic update so the UI reacts immediately at click, before the
+			// async permission/getUserMedia chain resolves and fires the 'start' event.
+			setIsRecording(true)
 			ref.current.start(options)
 		}
 	}, [])
@@ -50,7 +66,7 @@ const useVocal = (lang = 'en-US', grammars = null, maxAlternatives = 1, continuo
 		}
 	}, [])
 
-	return [ref, { start, stop, abort, subscribe, unsubscribe, clean }]
+	return [ref, { start, stop, abort, subscribe, unsubscribe, clean, isRecording }]
 }
 
 export default useVocal

--- a/src/hooks/useVocal.js
+++ b/src/hooks/useVocal.js
@@ -29,12 +29,13 @@ const useVocal = (lang = 'en-US', grammars = null, maxAlternatives = 1, continuo
 	}, [lang, grammars, maxAlternatives, continuous, __rsInstance, supported])
 
 	const start = useCallback((options) => {
-		if (ref.current) {
-			// Optimistic update so the UI reacts immediately at click, before the
-			// async permission/getUserMedia chain resolves and fires the 'start' event.
-			setIsRecording(true)
-			ref.current.start(options)
-		}
+		if (!ref.current) return undefined
+		// Optimistic update so the UI reacts immediately at click, before the
+		// async permission/getUserMedia chain resolves and fires the 'start' event.
+		setIsRecording(true)
+		// vocal 2.x's start() returns a Promise that rejects on microphone/permission
+		// errors. Returning it lets consumers await or attach a .catch handler.
+		return ref.current.start(options)
 	}, [])
 
 	const stop = useCallback(() => {

--- a/src/hooks/useVocal.js
+++ b/src/hooks/useVocal.js
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useRef } from 'react'
-import { Vocal as SpeechRecognitionWrapper } from '@untemps/vocal'
+import { createVocal, isSupported } from '@untemps/vocal'
 
 const useVocal = (lang = 'en-US', grammars = null, maxAlternatives = 1, continuous = false, __rsInstance = null) => {
 	const ref = useRef(null)
 
 	useEffect(() => {
-		if (SpeechRecognitionWrapper.isSupported) {
-			ref.current = __rsInstance || new SpeechRecognitionWrapper({ lang, grammars, maxAlternatives, continuous })
+		if (isSupported()) {
+			ref.current = __rsInstance || createVocal({ lang, grammars, maxAlternatives, continuous })
 			return () => {
 				ref.current.abort()
 				ref.current.cleanup()
@@ -34,13 +34,13 @@ const useVocal = (lang = 'en-US', grammars = null, maxAlternatives = 1, continuo
 
 	const subscribe = useCallback((eventType, handler) => {
 		if (ref.current) {
-			ref.current.addEventListener(eventType, handler)
+			ref.current.on(eventType, handler)
 		}
 	}, [])
 
 	const unsubscribe = useCallback((eventType, handler) => {
 		if (ref.current) {
-			ref.current.removeEventListener(eventType, handler)
+			ref.current.off(eventType, handler)
 		}
 	}, [])
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 import Vocal from './components/Vocal'
-import { Vocal as SpeechRecognitionWrapper } from '@untemps/vocal'
 
 export { default as useVocal } from './hooks/useVocal'
-export const isSupported = SpeechRecognitionWrapper.isSupported
+export { isSupported } from '@untemps/vocal'
 
 export default Vocal

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,19 +6,11 @@ export default defineConfig({
 	build: {
 		lib: {
 			entry: 'src/index.js',
-			name: 'ReactVocal',
-			formats: ['es', 'cjs', 'umd'],
-			fileName: (format) => ({ es: 'index.es.js', umd: 'index.umd.js', cjs: 'index.js' })[format],
+			formats: ['es', 'cjs'],
+			fileName: (format) => ({ es: 'index.es.js', cjs: 'index.js' })[format],
 		},
 		rollupOptions: {
 			external: ['react', 'react-dom', 'fuse.js'],
-			output: {
-				globals: {
-					react: 'React',
-					'react-dom': 'ReactDOM',
-					'fuse.js': 'Fuse',
-				},
-			},
 		},
 		sourcemap: true,
 	},

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -37,47 +37,64 @@ global.SpeechGrammarList = vi.fn(function () {
 		length: 0,
 	}
 })
+
+let currentSr = null
+global.__getSpeechRecognition = () => currentSr
+
 global.SpeechRecognition = vi.fn(function () {
 	const handlers = {}
 	let accumulatedResults = []
-	return {
+	const sr = {
 		addEventListener: vi.fn(function (type, callback) {
 			handlers[type] = callback
 		}),
-		removeEventListener: vi.fn(),
+		removeEventListener: vi.fn(function (type) {
+			delete handlers[type]
+		}),
 		dispatchEvent: vi.fn(),
 		start: vi.fn(function () {
 			accumulatedResults = []
-			handlers.start?.()
+			handlers.start?.(new Event('start'))
 		}),
 		stop: vi.fn(function () {
-			handlers.end?.()
+			handlers.end?.(new Event('end'))
 		}),
 		abort: vi.fn(function () {
-			handlers.end?.()
+			handlers.end?.(new Event('end'))
 		}),
 		say: vi.fn(function (input) {
-			handlers.speechstart?.()
+			handlers.speechstart?.(new Event('speechstart'))
 
 			const newSegments = Array.isArray(input) ? input : input ? [[{ transcript: input }]] : []
 			const resultIndex = accumulatedResults.length
-			accumulatedResults = [...accumulatedResults, ...newSegments]
+			const segmentsWithFinal = newSegments.map((segment) => {
+				const arr = segment.slice()
+				Object.defineProperty(arr, 'isFinal', { value: true })
+				Object.defineProperty(arr, 'item', { value: (i) => arr[i] })
+				return arr
+			})
+			accumulatedResults = [...accumulatedResults, ...segmentsWithFinal]
+
+			const resultsArray = accumulatedResults.slice()
+			Object.defineProperty(resultsArray, 'item', { value: (i) => resultsArray[i] })
 
 			const resultEvent = new Event('result')
 			resultEvent.resultIndex = resultIndex
-			resultEvent.results = accumulatedResults
-			handlers.speechend?.()
+			resultEvent.results = resultsArray
+			handlers.speechend?.(new Event('speechend'))
 			if (input) {
 				handlers.result?.(resultEvent)
 			} else {
-				handlers.nomatch?.()
+				handlers.nomatch?.(new Event('nomatch'))
 			}
 		}),
 		end: vi.fn(function () {
-			handlers.end?.()
+			handlers.end?.(new Event('end'))
 		}),
 		error: vi.fn(function (err) {
 			handlers.error?.(err)
 		}),
 	}
+	currentSr = sr
+	return sr
 })

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -44,26 +44,40 @@ global.__getSpeechRecognition = () => currentSr
 global.SpeechRecognition = vi.fn(function () {
 	const handlers = {}
 	let accumulatedResults = []
+
+	const fire = (type, event) => {
+		const list = handlers[type]
+		if (!list) return
+		for (const cb of list.slice()) cb(event)
+	}
+
 	const sr = {
 		addEventListener: vi.fn(function (type, callback) {
-			handlers[type] = callback
+			if (!handlers[type]) handlers[type] = []
+			handlers[type].push(callback)
 		}),
-		removeEventListener: vi.fn(function (type) {
-			delete handlers[type]
+		removeEventListener: vi.fn(function (type, callback) {
+			if (!handlers[type]) return
+			if (callback) {
+				handlers[type] = handlers[type].filter((cb) => cb !== callback)
+				if (handlers[type].length === 0) delete handlers[type]
+			} else {
+				delete handlers[type]
+			}
 		}),
 		dispatchEvent: vi.fn(),
 		start: vi.fn(function () {
 			accumulatedResults = []
-			handlers.start?.(new Event('start'))
+			fire('start', new Event('start'))
 		}),
 		stop: vi.fn(function () {
-			handlers.end?.(new Event('end'))
+			fire('end', new Event('end'))
 		}),
 		abort: vi.fn(function () {
-			handlers.end?.(new Event('end'))
+			fire('end', new Event('end'))
 		}),
 		say: vi.fn(function (input) {
-			handlers.speechstart?.(new Event('speechstart'))
+			fire('speechstart', new Event('speechstart'))
 
 			const newSegments = Array.isArray(input) ? input : input ? [[{ transcript: input }]] : []
 			const resultIndex = accumulatedResults.length
@@ -81,18 +95,18 @@ global.SpeechRecognition = vi.fn(function () {
 			const resultEvent = new Event('result')
 			resultEvent.resultIndex = resultIndex
 			resultEvent.results = resultsArray
-			handlers.speechend?.(new Event('speechend'))
+			fire('speechend', new Event('speechend'))
 			if (input) {
-				handlers.result?.(resultEvent)
+				fire('result', resultEvent)
 			} else {
-				handlers.nomatch?.(new Event('nomatch'))
+				fire('nomatch', new Event('nomatch'))
 			}
 		}),
 		end: vi.fn(function () {
-			handlers.end?.(new Event('end'))
+			fire('end', new Event('end'))
 		}),
 		error: vi.fn(function (err) {
-			handlers.error?.(err)
+			fire('error', err)
 		}),
 	}
 	currentSr = sr

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -38,20 +38,19 @@ global.SpeechGrammarList = vi.fn(function () {
 	}
 })
 
-let currentSr = null
-global.__getSpeechRecognition = () => currentSr
-
+// Minimal SpeechRecognition mock used by tests that create a real `createVocal()`
+// instance (i.e. tests that don't inject a __rsInstance mock). Just enough to make
+// vocal 2.x's isSupported()/start() chain succeed and forward start/end events.
+// Tests that need to simulate speech results inject a createMockVocal() instance
+// instead — see src/components/__tests__/createMockVocal.js.
 global.SpeechRecognition = vi.fn(function () {
 	const handlers = {}
-	let accumulatedResults = []
-
 	const fire = (type, event) => {
 		const list = handlers[type]
 		if (!list) return
 		for (const cb of list.slice()) cb(event)
 	}
-
-	const sr = {
+	return {
 		addEventListener: vi.fn(function (type, callback) {
 			if (!handlers[type]) handlers[type] = []
 			handlers[type].push(callback)
@@ -67,7 +66,6 @@ global.SpeechRecognition = vi.fn(function () {
 		}),
 		dispatchEvent: vi.fn(),
 		start: vi.fn(function () {
-			accumulatedResults = []
 			fire('start', new Event('start'))
 		}),
 		stop: vi.fn(function () {
@@ -76,39 +74,5 @@ global.SpeechRecognition = vi.fn(function () {
 		abort: vi.fn(function () {
 			fire('end', new Event('end'))
 		}),
-		say: vi.fn(function (input) {
-			fire('speechstart', new Event('speechstart'))
-
-			const newSegments = Array.isArray(input) ? input : input ? [[{ transcript: input }]] : []
-			const resultIndex = accumulatedResults.length
-			const segmentsWithFinal = newSegments.map((segment) => {
-				const arr = segment.slice()
-				Object.defineProperty(arr, 'isFinal', { value: true })
-				Object.defineProperty(arr, 'item', { value: (i) => arr[i] })
-				return arr
-			})
-			accumulatedResults = [...accumulatedResults, ...segmentsWithFinal]
-
-			const resultsArray = accumulatedResults.slice()
-			Object.defineProperty(resultsArray, 'item', { value: (i) => resultsArray[i] })
-
-			const resultEvent = new Event('result')
-			resultEvent.resultIndex = resultIndex
-			resultEvent.results = resultsArray
-			fire('speechend', new Event('speechend'))
-			if (input) {
-				fire('result', resultEvent)
-			} else {
-				fire('nomatch', new Event('nomatch'))
-			}
-		}),
-		end: vi.fn(function () {
-			fire('end', new Event('end'))
-		}),
-		error: vi.fn(function (err) {
-			fire('error', err)
-		}),
 	}
-	currentSr = sr
-	return sr
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1057,22 +1057,22 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz#56e2cc26c397c038fab0e3a917a12d5c5909e901"
   integrity sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==
 
-"@untemps/user-permissions-utils@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@untemps/user-permissions-utils/-/user-permissions-utils-1.1.0.tgz#133b3628f4691b11008444ffbfbbf82375b1f8ef"
-  integrity sha512-0QLjzj9JIFZc+YGs2QnTh3ic9a4MCvPvtkL/SrtgWU7vw9bmtra2FnHfFr4vp8OtyLLzoTo3UGCvXP92VnOIDw==
+"@untemps/user-permissions-utils@^1.3.3":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@untemps/user-permissions-utils/-/user-permissions-utils-1.3.4.tgz#f7e66f4e5f77d47a5e7f4c2e4b2d3db83f79a8fa"
+  integrity sha512-pVZ8S4EGWugDUf74cwsHs8TO7aheBqKFyqdIS33wIVEqxuo4S7anDtdwg/gFDx7RZ6LoQ6Mi3Iz3T2wsJu6JKw==
 
 "@untemps/utils@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@untemps/utils/-/utils-3.2.0.tgz#dc26d65d54e4a5e9b940b5c7f65832f60ff283dd"
   integrity sha512-P48fcASTI8LSngn8cYjDq8KkasjDLghOnDmMatjwTLp0/qwp8/sifYuAJDODCqXXr7xATxcTnkULzNdZqavuNA==
 
-"@untemps/vocal@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@untemps/vocal/-/vocal-1.3.0.tgz#85877e7ff00bb88591586383c56c4ea15871ea1c"
-  integrity sha512-i4GyGM1WL41XpnEidURVcBbu+jJLWsi7JMUzpS3XjPqFHAaK1nm4GP9ZwCEGrfIYDEMM65a62kNNxxi7Vmpm3Q==
+"@untemps/vocal@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@untemps/vocal/-/vocal-2.0.1.tgz#67b45c70817f07d355ce1aa029220ae6c8a2a3c1"
+  integrity sha512-TBRxtkzA2d7/RHkDIHBUf9WUiPPZKrLjB4sfVluWbfuO1MPpBqchg0TaJCtMjiYwbI56sdbM2VHtZjSk4xfmlA==
   dependencies:
-    "@untemps/user-permissions-utils" "^1.1.0"
+    "@untemps/user-permissions-utils" "^1.3.3"
 
 "@vitejs/plugin-react@^6.0.1":
   version "6.0.1"


### PR DESCRIPTION
## Summary
Bumps `@untemps/vocal` from `^1.3.0` to `^2.0.1` and adapts the library to the new factory-based API (`createVocal`, `on`/`off`, `isSupported` as a function). The public `useVocal` tuple stays structurally identical for consumers — `subscribe`/`unsubscribe` delegate to the instance's `on`/`off` under the hood.

Closes #139.

## Changes
- `src/index.js` — re-exports `isSupported` directly from `@untemps/vocal` (now a function, was a boolean snapshot).
- `src/hooks/useVocal.js` — uses `createVocal({...})` instead of `new SpeechRecognitionWrapper({...})`, and `isSupported()` / `on` / `off` instead of the legacy getter and `addEventListener`/`removeEventListener` methods.
- `src/components/Vocal.jsx` — calls `isSupported()` instead of reading the static getter.
- `vitest.setup.js` — exposes `globalThis.__getSpeechRecognition()` to access the last `SpeechRecognition` instance built by the global mock (replaces the removed `wrapper.instance` getter). Each result segment created by `say()` is decorated with `isFinal` and `item()` to match the shape vocal 2.x expects.
- `src/hooks/__tests__/useVocal.test.js` — mocks `createVocal` and `isSupported` as named exports of `@untemps/vocal` (was: mocking the `Vocal` class constructor and `isSupported` getter).
- `src/components/__tests__/Vocal.test.jsx` — ~40 `recognition.instance.say/.error/.end` call sites switched to `getSr().say/.error/.end`. `new SpeechRecognitionWrapper()` → `createVocal()`. `recognition.addEventListener(...)` → `recognition.on(...)`. Partial mock of `@untemps/vocal` (via `vi.mock` + `importOriginal`) so that `isSupported` is spy-able while `createVocal` stays real.
- `README.md`, `CLAUDE.md` — updated terminology and the `isSupported` usage example.

## Validation
- `yarn test:ci` — **91 / 91 tests pass**, coverage held at 100% statements / functions / lines, 92.31% branches.
- `yarn build` — CJS + ES + UMD bundles produced successfully (one pre-existing `MIXED_EXPORTS` warning, not introduced by this PR).
- `yarn prettier` — no formatting changes.
- `dev/` playground — `yarn build` in `dev/` compiles cleanly (Vite, 30 modules).

## Test plan
- [ ] `yarn install && yarn test:ci` locally — expect 91 passing tests
- [ ] `yarn build` — expect dist/index.{js,es.js,umd.js}
- [ ] `yarn dev` — start the playground, click the mic in a Web Speech-capable browser, confirm command matching, transcript rendering, and continuous mode toggle still behave as before

## ⚠️ Breaking changes
- **`isSupported`** is now a function instead of a boolean.

  Migration:
  ```js
  // before
  import { isSupported } from '@untemps/react-vocal'
  if (isSupported) { ... }

  // after
  import { isSupported } from '@untemps/react-vocal'
  if (isSupported()) { ... }
  ```

  Bonus: the function form is SSR-safe (returns `false` when `window` is undefined), so consumers no longer need a manual `typeof window` guard.

## Follow-up
Five companion issues track the new capabilities and refactors enabled by vocal 2.x but kept out of this PR to keep scope tight:

- #140 — Expose `AbortSignal` in `start()`
- #141 — Expose `isRecording` from `useVocal`
- #142 — Simplify `_onResult` using `bestAlternative`
- #143 — Drop manual continuous-mode accumulation
- #145 — Consider dropping UMD bundle

The test refactor planned in #144 partially landed here (handle-based access to the mocked `SpeechRecognition`); a deeper move to a `createMockVocal()` helper is still tracked there.