### PR TITLE
fix: Race condition in useCommands — stale Fuse instance after async import

### DIFF
--- a/src/hooks/__tests__/useCommands.test.js
+++ b/src/hooks/__tests__/useCommands.test.js
@@ -112,4 +112,22 @@ describe('useCommands', () => {
 		expect(triggerCommand('change color')).toBe('matched')
 		vi.doUnmock('fuse.js')
 	})
+
+	it('discards the dynamic fuse.js import result when the effect is cleaned up before it resolves', async () => {
+		// Without the cancellation guard, the .catch() branch would fire console.warn
+		// even after the component unmounted (stale effect). With the guard, the
+		// cleanup runs before the import settles and the .catch() is skipped.
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+		vi.doMock('fuse.js', () => {
+			throw new Error('fuse.js not installed')
+		})
+		const { default: useCommandsFresh } = await import('../useCommands')
+		const commands = { 'change color': () => 'matched' }
+		const { unmount } = renderHook(() => useCommandsFresh(commands))
+		unmount()
+		await act(async () => {})
+		expect(warnSpy).not.toHaveBeenCalled()
+		warnSpy.mockRestore()
+		vi.doUnmock('fuse.js')
+	})
 })

--- a/src/hooks/useCommands.js
+++ b/src/hooks/useCommands.js
@@ -23,12 +23,18 @@ const useCommands = (commands, precision = 0.4) => {
 			fuseRef.current = null
 			return
 		}
+		// Race guard: if the effect re-runs (keys change) or unmounts before the dynamic
+		// import resolves, discard the .then()/.catch() result so a stale Fuse instance
+		// can't overwrite fuseRef.current.
+		let cancelled = false
 		import('fuse.js')
 			.then((module) => {
+				if (cancelled) return
 				const Fuse = module.default ?? module
 				fuseRef.current = new Fuse(keys, { includeScore: true, ignoreLocation: true })
 			})
 			.catch(() => {
+				if (cancelled) return
 				if (process.env.NODE_ENV !== 'production') {
 					console.warn(
 						'[react-vocal] fuse.js is not installed. Phrase command keys will fall back to exact matching. ' +
@@ -36,6 +42,9 @@ const useCommands = (commands, precision = 0.4) => {
 					)
 				}
 			})
+		return () => {
+			cancelled = true
+		}
 	}, [hasPhraseKeys, keys])
 
 	const triggerCommand = (rawInput) => {


### PR DESCRIPTION
## Summary
The `useEffect` in `useCommands` that dynamically imports `fuse.js` returned no cleanup function. When the effect re-ran (commands prop changed) or the component unmounted before the import resolved, the `.then()` callback would overwrite `fuseRef.current` with a stale Fuse instance, and the `.catch()` would fire `console.warn` on an unmounted component. This PR adds a `cancelled` flag and a cleanup function so both branches early-return when the effect has been torn down.

Closes #121.

## Changes
- `src/hooks/useCommands.js` — declare `let cancelled = false` at the start of the dynamic-import branch; guard the `.then()` write and the `.catch()` warn behind `if (cancelled) return`; return `() => { cancelled = true }` as the effect cleanup.
- `src/hooks/__tests__/useCommands.test.js` — new test asserting that `console.warn` is not invoked when the hook unmounts before the dynamic `fuse.js` import resolves (mocked to throw). Without the guard, `.catch()` fires the warning on a torn-down effect.

## Test plan
- [ ] `yarn install && yarn test:ci` — expect 99 passing tests (98 prior + 1 new)
- [ ] Manually toggle the `commands` prop quickly between a phrase-key shape (e.g. `{ 'change color': fn }`) and a single-word shape (`{ red: fn }`) in the dev playground — no `console.warn` should appear, and command matching should reflect the latest prop.

## Notes
No breaking change — purely a correctness fix on an internal race window. Functional impact was low (stale Fuse instance was leaked but not consulted in the single-word branch), but the warning leak and the potential overwrite were genuine correctness issues.