### PR TITLE
fix: Decorative SVG in Icon missing aria-hidden

### DIFF
--- a/src/components/Icon.jsx
+++ b/src/components/Icon.jsx
@@ -8,6 +8,7 @@ const Icon = ({ color = 'black', activeColor = 'red', isActive = false }) => {
 			width="100%"
 			height="100%"
 			viewBox="0 0 24 24"
+			aria-hidden="true"
 		>
 			<g>
 				<path

--- a/src/components/__tests__/Icon.test.jsx
+++ b/src/components/__tests__/Icon.test.jsx
@@ -17,6 +17,11 @@ describe('Icon', () => {
 		expect(queryByTestId('__icon-root__')).toBeInTheDocument()
 	})
 
+	it('hides the decorative SVG from the accessibility tree', () => {
+		const { queryByTestId } = render(getInstance())
+		expect(queryByTestId('__icon-root__')).toHaveAttribute('aria-hidden', 'true')
+	})
+
 	it('renders component color', () => {
 		const color = 'green'
 		const { queryByTestId } = render(getInstance({ color }))

--- a/src/components/__tests__/__snapshots__/Icon.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/Icon.test.jsx.snap
@@ -3,6 +3,7 @@
 exports[`Icon > matches snapshot 1`] = `
 <DocumentFragment>
   <svg
+    aria-hidden="true"
     data-testid="__icon-root__"
     height="100%"
     viewBox="0 0 24 24"

--- a/src/components/__tests__/__snapshots__/Vocal.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/Vocal.test.jsx.snap
@@ -9,6 +9,7 @@ exports[`Vocal > matches snapshot 1`] = `
     style="width: 24px; height: 24px; background-color: transparent; border: medium; padding: 0px; cursor: pointer;"
   >
     <svg
+      aria-hidden="true"
       data-testid="__icon-root__"
       height="100%"
       viewBox="0 0 24 24"


### PR DESCRIPTION
## Summary
The `Icon` SVG is rendered inside a `<button>` whose `aria-label` already describes the action ("start recognition" by default). Without `aria-hidden=\"true\"` on the SVG, screen readers may attempt to describe the SVG's content in addition to the button label — producing redundant or noisy announcements. This PR adds the attribute and locks it with an explicit accessibility test.

Closes #123.

## Changes
- `src/components/Icon.jsx` — add `aria-hidden=\"true\"` on the `<svg>` element.
- `src/components/__tests__/Icon.test.jsx` — new test `hides the decorative SVG from the accessibility tree` asserting the attribute is present. The snapshot test is preserved as a structural backstop, but the explicit assertion locks the contract beyond snapshot fragility.
- `src/components/__tests__/__snapshots__/Icon.test.jsx.snap` and `Vocal.test.jsx.snap` — regenerated to include the new attribute.

## Test plan
- [ ] `yarn install && yarn test:ci` — expect 100 passing tests (99 prior + 1 new), no snapshot diffs.
- [ ] Manually verify the default `<Vocal />` button in a screen reader (VoiceOver, NVDA, JAWS) announces only the `aria-label` and not the SVG path content.

## Notes
No breaking change — purely an accessibility fix. The SVG remains visually identical.