### PR TITLE
docs: Fix invalid BCP-47 locale in useVocal example

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ const App = () => {
 	const [isListening, setIsListening] = useState(false)
 	const [result, setResult] = useState('')
 
-	const [, { start, subscribe }] = useVocal('fr_FR')
+	const [, { start, subscribe }] = useVocal('fr-FR')
 
 	const _onButtonClick = () => {
 		setIsListening(true)


### PR DESCRIPTION
## Summary
The `useVocal` basic usage block in `README.md` used `'fr_FR'` (underscore), which is not a valid BCP-47 language tag. Developers copying the snippet verbatim would pass an invalid tag to the underlying `SpeechRecognition` instance, which may silently fall back to a default language or misrecognize speech. Replaces it with the correct `'fr-FR'` (hyphen).

Closes #124.

## Changes
- `README.md` — `useVocal('fr_FR')` → `useVocal('fr-FR')` in the basic usage example.

## Test plan
- [ ] Visually verify the rendered README on GitHub shows `useVocal('fr-FR')` in the basic usage code block.

## Notes
Pure documentation fix — no code change, no breaking change.