### PR TITLE
chore!: Align package.json with @untemps/vocal 2.x packaging shape

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Run a single test file:
 yarn vitest src/hooks/__tests__/useVocal.test.js
 ```
 
-Build formats defined in `vite.config.js` `build.lib`: `cjs` → `dist/index.js`, `es` → `dist/index.es.js`.
+Build formats defined in `vite.config.js` `build.lib`: `cjs` → `dist/index.cjs`, `es` → `dist/index.es.js`.
 
 ## Architecture
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,7 +1,7 @@
-module.exports = {
+export default {
 	extends: ['@commitlint/config-conventional'],
 	rules: {
 		'subject-case': [2, 'always', ['sentence-case']],
-		'scope-case': [2, 'always', ['lower-case', 'upper-case']]
+		'scope-case': [2, 'always', ['lower-case', 'upper-case']],
 	},
 }

--- a/dev/package.json
+++ b/dev/package.json
@@ -2,6 +2,7 @@
 	"name": "react-vocal-demo",
 	"version": "1.0.0",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite",
 		"build": "vite build",

--- a/package.json
+++ b/package.json
@@ -21,12 +21,21 @@
 		"access": "public"
 	},
 	"files": [
-		"dist/index.js",
+		"dist/index.cjs",
 		"dist/index.es.js",
 		"CHANGELOG.md"
 	],
-	"main": "dist/index.js",
+	"type": "module",
+	"main": "dist/index.cjs",
 	"module": "dist/index.es.js",
+	"sideEffects": false,
+	"exports": {
+		".": {
+			"import": "./dist/index.es.js",
+			"require": "./dist/index.cjs",
+			"default": "./dist/index.es.js"
+		}
+	},
 	"engines": {
 		"node": "^20.19.0 || >=22.12.0"
 	},
@@ -94,7 +103,7 @@
 				{
 					"assets": [
 						{
-							"path": "dist/index.js",
+							"path": "dist/index.cjs",
 							"label": "CJS distribution"
 						},
 						{

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
 		lib: {
 			entry: 'src/index.js',
 			formats: ['es', 'cjs'],
-			fileName: (format) => ({ es: 'index.es.js', cjs: 'index.js' })[format],
+			fileName: (format) => ({ es: 'index.es.js', cjs: 'index.cjs' })[format],
 		},
 		rollupOptions: {
 			external: ['react', 'react-dom', 'fuse.js'],


### PR DESCRIPTION
## Summary
Adopts the same packaging layout as the underlying \`@untemps/vocal\` package: adds a formal \`exports\` map, \`type: "module"\`, \`sideEffects: false\`, and renames the CJS bundle from \`dist/index.js\` to \`dist/index.cjs\`. Brings react-vocal up to date with modern Node packaging conventions and closes the door on sub-path imports for bundlers that respect the \`exports\` field.

Closes #125.

## Changes
- \`package.json\`:
  - Add \`type: "module"\` so source \`.js\` files (which use ESM syntax) are interpreted as such by Node.
  - Add \`sideEffects: false\` for tree-shaking — verified by inspecting all source files (no CSS imports, no init scripts).
  - Add an \`exports\` map with \`import\` / \`require\` / \`default\` conditions pointing to \`dist/index.es.js\` and \`dist/index.cjs\`.
  - Keep \`main\` and \`module\` for older bundlers that don't read \`exports\` — both updated to the new paths.
  - Rename \`dist/index.js\` → \`dist/index.cjs\` in \`files\` and in the semantic-release github assets list.
- \`vite.config.js\`: change the CJS \`fileName\` mapping from \`'index.js'\` to \`'index.cjs'\`.
- \`commitlint.config.js\`: convert to ESM (\`export default\`) so it loads correctly under \`type: "module"\`.
- \`CLAUDE.md\`: update the build-formats line accordingly.

## Validation
- \`yarn test:ci\` — **100 / 100 tests pass**.
- \`yarn build\` — produces \`dist/index.cjs\` (15.71 kB) and \`dist/index.es.js\` (19.16 kB), no more \`dist/index.js\`.
- \`yarn prettier\` — no formatting changes.
- \`dev/\` playground — \`yarn build\` succeeds.

## Test plan
- [ ] \`yarn install && yarn test:ci\` locally — expect 100 passing tests.
- [ ] \`yarn build\` — expect \`dist/index.cjs\` and \`dist/index.es.js\` only.
- [ ] Sanity check a consumer install: in a fresh package, \`require('@untemps/react-vocal')\` resolves to the CJS bundle and \`import\` resolves to the ES bundle (via the \`exports\` conditions).

## ⚠️ Breaking changes

### CJS bundle renamed from \`dist/index.js\` to \`dist/index.cjs\`
- Consumers using the standard package entry point (\`require('@untemps/react-vocal')\` or \`import\`) are **not affected** — \`main\` / \`module\` / \`exports\` all resolve to the new paths automatically.
- Consumers that hard-coded a deep require to \`@untemps/react-vocal/dist/index.js\` must update the path to \`@untemps/react-vocal/dist/index.cjs\`.

### Sub-path imports rejected under \`exports\`
- Bundlers that respect the \`exports\` map will reject any import path other than the package root (e.g. \`import foo from '@untemps/react-vocal/dist/index.es.js'\` will fail). This is the intended outcome — the \`exports\` map formalizes the public API surface. Switch to the package entry import.