### PR TITLE
chore: Replace ineffective waitFor(() => flag) pattern in tests

### DIFF
--- a/src/components/__tests__/Vocal.test.jsx
+++ b/src/components/__tests__/Vocal.test.jsx
@@ -152,16 +152,11 @@ describe('Vocal', () => {
 		const commands = { foo: callback }
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, commands }))
 
-		let flag = false
-		recognition.on('start', async () => {
-			flag = true
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
 		})
 
 		await act(async () => {
-			fireEvent.click(getByTestId('__vocal-root__'))
-
-			await waitFor(() => flag)
-
 			recognition.say('Foo')
 			await waitFor(() => expect(callback).toHaveBeenCalledWith('Foo', 'foo'))
 		})
@@ -181,16 +176,11 @@ describe('Vocal', () => {
 		const recognition = createMockVocal()
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onResult }))
 
-		let flag = false
-		recognition.on('start', async () => {
-			flag = true
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
 		})
 
 		await act(async () => {
-			fireEvent.click(getByTestId('__vocal-root__'))
-
-			await waitFor(() => flag)
-
 			recognition.say('Foo')
 			await waitFor(() => expect(onResult).toHaveBeenCalledWith('Foo', expect.anything()))
 		})
@@ -201,16 +191,11 @@ describe('Vocal', () => {
 		const recognition = createMockVocal()
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onNoMatch }))
 
-		let flag = false
-		recognition.on('start', async () => {
-			flag = true
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
 		})
 
 		await act(async () => {
-			fireEvent.click(getByTestId('__vocal-root__'))
-
-			await waitFor(() => flag)
-
 			recognition.say(null)
 			await waitFor(() => expect(onNoMatch).toHaveBeenCalled())
 		})
@@ -221,16 +206,11 @@ describe('Vocal', () => {
 		const recognition = createMockVocal()
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onSpeechStart }))
 
-		let flag = false
-		recognition.on('start', async () => {
-			flag = true
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
 		})
 
 		await act(async () => {
-			fireEvent.click(getByTestId('__vocal-root__'))
-
-			await waitFor(() => flag)
-
 			recognition.say('Foo')
 			await waitFor(() => expect(onSpeechStart).toHaveBeenCalled())
 		})
@@ -241,16 +221,11 @@ describe('Vocal', () => {
 		const recognition = createMockVocal()
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onSpeechEnd }))
 
-		let flag = false
-		recognition.on('start', async () => {
-			flag = true
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
 		})
 
 		await act(async () => {
-			fireEvent.click(getByTestId('__vocal-root__'))
-
-			await waitFor(() => flag)
-
 			recognition.say('Foo')
 			await waitFor(() => expect(onSpeechEnd).toHaveBeenCalled())
 		})
@@ -271,16 +246,11 @@ describe('Vocal', () => {
 		const recognition = createMockVocal()
 		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onEnd }))
 
-		let flag = false
-		recognition.on('start', async () => {
-			flag = true
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
 		})
 
 		await act(async () => {
-			fireEvent.click(getByTestId('__vocal-root__'))
-
-			await waitFor(() => flag)
-
 			recognition.say('Foo')
 			await waitFor(() => expect(onEnd).toHaveBeenCalled())
 		})


### PR DESCRIPTION
## Summary
Six tests in `Vocal.test.jsx` used the same synchronization pattern: subscribe a flag handler to the `'start'` event, then `await waitFor(() => flag)` before firing speech events. The pattern is ineffective — `waitFor` resolves as soon as the predicate does not throw, and returning `false` does not throw, so the wait resolves immediately regardless of the flag value. This PR replaces the pattern with the cleaner two-step `act` flow already used by the Continuous sessions tests.

Closes #126.

## Changes
- `src/components/__tests__/Vocal.test.jsx` — for the six affected tests (`responds to command`, `triggers onResult handler`, `triggers onNoMatch handler`, `triggers onSpeechStart handler`, `triggers onSpeechEnd handler`, `triggers onEnd handler after speech`):
  - Drop `let flag = false`
  - Drop `recognition.on('start', async () => { flag = true })`
  - Drop `await waitFor(() => flag)`
  - Split the `act` into two: a first `await act` wraps the click (flushes the start microtask), a second `await act` wraps the `recognition.say(...)` call and its assertion.

## Test plan
- [ ] `yarn install && yarn test:ci` — expect 100 passing tests (same count as before).
- [ ] The six refactored tests still validate their respective handlers (onResult, onNoMatch, onSpeechStart, onSpeechEnd, onEnd, command callback) and the trigger semantics — only the synchronization scaffolding changed.

## Notes
No behavioral change. Net diff: −30 lines (removal of the flag scaffolding is larger than the additional `act` wrapper).