### PR TITLE
chore: Configure coverage thresholds in vitest

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -23,6 +23,12 @@ export default defineConfig({
 			provider: 'v8',
 			reporter: ['text', 'lcov'],
 			reportsDirectory: './coverage',
+			thresholds: {
+				lines: 90,
+				functions: 90,
+				branches: 85,
+				statements: 90,
+			},
 		},
 	},
 })


### PR DESCRIPTION
## Summary
Adds a \`thresholds\` block to the vitest coverage config so a meaningful coverage regression breaks \`yarn test:ci\` instead of silently passing. Values are picked below the current coverage levels to leave room for legitimate refactors while still catching real drops.

Closes #128.

## Changes
- \`vite.config.js\` — add \`thresholds: { lines: 90, functions: 90, branches: 85, statements: 90 }\` to the \`test.coverage\` block.

## Validation
Current coverage levels are well above the new thresholds:

| Metric | Current | Threshold | Margin |
|--------|---------|-----------|--------|
| Statements | 98.18% | 90% | +8.18 |
| Branches | 91.28% | 85% | +6.28 |
| Functions | 98.53% | 90% | +8.53 |
| Lines | 99.17% | 90% | +9.17 |

\`yarn test:ci\` passes with no threshold violation (vitest only reports threshold output when one fails — silence = pass).

## Test plan
- [ ] \`yarn install && yarn test:ci\` locally — expect 100 passing tests and no threshold error.
- [ ] (optional) Lower a threshold to 100 temporarily and run \`yarn test:ci\` — it should fail with a coverage threshold error, confirming the enforcement is active.

## Notes
The branches margin (+6.28) is the tightest. If a future refactor consumes more than 6% of the branches budget, the threshold breaks — that's the intended behavior. The 85% target for branches is more permissive than the 90% picked for the other metrics to account for the natural volatility of branch coverage during refactors.