### PR TITLE
docs: Clarify clean description in useVocal return value table

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ const [ref, { start, stop, abort, subscribe, unsubscribe, clean, isRecording }]
 | abort       | func | Function to abort the recognition                    |
 | subscribe   | func | Function to subscribe to recognition events          |
 | unsubscribe | func | Function to unsubscribe to recognition events        |
-| clean       | func | Function to clean subscription to recognition events |
+| clean       | func | Function to remove all event listeners and clean up the recognition instance |
 | isRecording | bool | Reactive flag mirroring whether a session is active. `true` between `start()` and the next `end`/`error` event. Updated optimistically on `start()` so the UI re-renders at click time. |
 
 #### Cancelling a start in flight


### PR DESCRIPTION
## Summary
The \`clean\` row exists in the \`useVocal\` return value table but its description (\"Function to clean subscription to recognition events\") is narrower than what the function actually does. It delegates to \`vocal.cleanup()\` which stops the session, removes every registered listener, and nullifies the SpeechRecognition instance. This PR adopts the more accurate wording proposed in the issue.

Closes #130.

## Changes
- \`README.md\` — \`useVocal\` return value table, \`clean\` row description:
  - Before: \`Function to clean subscription to recognition events\`
  - After: \`Function to remove all event listeners and clean up the recognition instance\`

## Test plan
- [ ] Visually verify the rendered README on GitHub shows the updated description.

## Notes
Pure documentation polish — no code change, no breaking change.