### PR TITLE
chore: Wrap _onFocus and _onBlur in useCallback

### DIFF
--- a/src/components/Vocal.jsx
+++ b/src/components/Vocal.jsx
@@ -192,17 +192,17 @@ const Vocal = ({
 		}
 	}, [HANDLERS, subscribe, start, stopSilenceTimer, _onError, signal])
 
-	const _onFocus = () => {
+	const _onFocus = useCallback(() => {
 		if (!className && outlineStyle) {
 			buttonRef.current.style.outline = outlineStyle
 		}
-	}
+	}, [className, outlineStyle])
 
-	const _onBlur = () => {
+	const _onBlur = useCallback(() => {
 		if (!className && outlineStyle) {
 			buttonRef.current.style.outline = 'none'
 		}
-	}
+	}, [className, outlineStyle])
 
 	const _renderDefault = () => (
 		<button


### PR DESCRIPTION
## Summary
Aligns the two focus/blur handlers in \`Vocal.jsx\` with the rest of the component — every other event handler (\`_onStart\`, \`_onEnd\`, \`_onResult\`, \`_onSpeechStart\`, etc.) is wrapped in \`useCallback\`. Memoizing these two avoids re-creating the handler functions on every render when \`className\` and \`outlineStyle\` are unchanged.

Closes #131.

## Changes
- \`src/components/Vocal.jsx\` — wrap \`_onFocus\` and \`_onBlur\` in \`useCallback\` with deps \`[className, outlineStyle]\` (the only props they read).

## Test plan
- [ ] \`yarn install && yarn test:ci\` — expect 100 passing tests (existing focus/blur tests cover the handlers).

## Notes
Purely a code-style consistency change. No behavioral difference.