### PR TITLE
feat: Export useCommands and fix README result callback examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,8 +379,8 @@ const App = () => {
 
 	const [, { start, subscribe }] = useVocal('fr-FR')
 
-	const _onResult = (transcript) => {
-		triggerCommand(transcript)
+	const _onResult = (_event, bestAlternative) => {
+		triggerCommand(bestAlternative)
 	}
 
 	const _onClick = () => {

--- a/README.md
+++ b/README.md
@@ -361,6 +361,57 @@ const [, { start }] = useVocal('en-US')
 start({ signal: controller.signal })
 ```
 
+### `useCommands` hook
+
+The `useCommands` hook is the same command-matching primitive used internally by the `Vocal` component. Export it directly when you build a custom UI on top of `useVocal` and want to reuse the matching logic instead of re-implementing it.
+
+#### Basic usage
+
+```javascript
+import { useVocal, useCommands } from '@untemps/react-vocal'
+
+const App = () => {
+	const commands = {
+		rouge: () => setBorderColor('red'),
+		bleu: () => setBorderColor('blue'),
+	}
+	const triggerCommand = useCommands(commands)
+
+	const [, { start, subscribe }] = useVocal('fr-FR')
+
+	const _onResult = (transcript) => {
+		triggerCommand(transcript)
+	}
+
+	const _onClick = () => {
+		subscribe('result', _onResult)
+		start()
+	}
+
+	return <button onClick={_onClick}>Listen</button>
+}
+```
+
+#### Signature
+
+```
+useCommands(commands, precision)
+```
+
+| Args      | Type   | Default | Description                                                                                              |
+| --------- | ------ | ------- | -------------------------------------------------------------------------------------------------------- |
+| commands  | object | null    | A `{ key: callback }` map. Keys are lowercased internally. Callbacks receive `(rawInput, commandKey)`.   |
+| precision | number | 0.4     | Fuse.js score threshold for **phrase** command keys only (lower = stricter). Single-word keys use exact lookup. |
+
+#### Return value
+
+`useCommands` returns a `triggerCommand(rawInput)` function. Passing a transcript runs it against the commands map and invokes the matching callback if any, returning its result. Returns `null` when no command matches.
+
+Matching rules:
+
+- **Single-word keys** (e.g. `rouge`, `submit`): exact case-insensitive lookup, with each word of the input tried individually so a key fires even when embedded in a phrase (`je veux du rouge` triggers `rouge`).
+- **Phrase keys** (e.g. `change the background color`): Fuse.js fuzzy matching against the joined transcript, gated by `precision`. fuse.js is loaded lazily; if it's not installed, the hook falls back to substring matching.
+
 ### Browser support flag
 
 #### Basic usage

--- a/README.md
+++ b/README.md
@@ -284,10 +284,10 @@ const App = () => {
 		setResult('')
 	}
 
-	const _onVocalResult = (result) => {
+	const _onVocalResult = (_event, bestAlternative) => {
 		setIsListening(false)
 
-		setResult(result)
+		setResult(bestAlternative)
 	}
 
 	const _onVocalError = (e) => {

--- a/src/hooks/__tests__/useVocal.test.ts
+++ b/src/hooks/__tests__/useVocal.test.ts
@@ -218,6 +218,28 @@ describe('useVocal', () => {
 			expect(mockOn).toHaveBeenCalled()
 		})
 
+		it('forwards the vocal 2.x result callback signature unchanged', () => {
+			// Locks the contract: a handler subscribed via subscribe('result', cb)
+			// receives (event, bestAlternative, alternatives) — matching
+			// @untemps/vocal's ResultEventHandler. The README examples for both
+			// useVocal and useCommands rely on this signature.
+			const handler = vi.fn()
+			const {
+				result: {
+					current: [, { subscribe }],
+				},
+			} = renderHook(() => useVocal())
+			subscribe('result', handler)
+			const registered = mockOn.mock.calls.find(([type]) => type === 'result')![1] as (
+				event: Event,
+				bestAlternative: string,
+				alternatives: string[]
+			) => void
+			const fakeEvent = new Event('result')
+			registered(fakeEvent, 'hello', ['hello'])
+			expect(handler).toHaveBeenCalledWith(fakeEvent, 'hello', ['hello'])
+		})
+
 		it('triggers unsubscribe function', () => {
 			const {
 				result: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import Vocal from './components/Vocal'
 
 export { default as useVocal } from './hooks/useVocal'
 export type { UseVocalActions, UseVocalReturn } from './hooks/useVocal'
+export { default as useCommands } from './hooks/useCommands'
 export type { CommandCallback, CommandsMap, TriggerCommand } from './hooks/useCommands'
 export type { VocalProps, OnResultCallback } from './components/Vocal'
 export { isSupported } from '@untemps/vocal'


### PR DESCRIPTION
## Summary
Exposes `useCommands` at runtime (the types were already published since the TypeScript migration #156) so consumers building custom UIs on top of `useVocal` can reuse the same command-matching primitive used internally by `Vocal`. Documents the hook in the README and fixes two pre-existing examples that misused the vocal 2.x RESULT callback signature.

Closes #134.

## Changes
- `src/index.ts` — add `export { default as useCommands } from './hooks/useCommands'`.
- `README.md` — new `### useCommands hook` section with basic usage, signature table, return contract, and matching-rules summary.
- `README.md` — fix `useCommands` example: `(transcript)` → `(_event, bestAlternative)` to match vocal 2.x's `ResultEventHandler = (event, bestAlternative, alternatives) => void`.
- `README.md` — fix pre-existing `useVocal` example (basic usage): `(result)` → `(_event, bestAlternative)`. The `subscribe('result', _onVocalResult)` callback was naming the first argument `result` even though it actually received the SpeechRecognitionEvent object.
- `src/hooks/__tests__/useVocal.test.ts` — regression test that locks the result callback signature: a handler subscribed via `subscribe('result', …)` is invoked with `(event, bestAlternative, alternatives)` exactly.

## Validation
- `yarn typecheck` clean.
- `yarn lint` clean.
- `yarn test:ci` — **101 / 101 tests pass** (100 previous + 1 new).
- `yarn build` — `dist/index.d.ts` includes `export declare const useCommands: (commands?: CommandsMap | null, precision?: number) => TriggerCommand`.

## Test plan
- [ ] `yarn install && yarn test:ci` locally — expect 101 passing tests.
- [ ] In a downstream consumer: `import { useCommands } from '@untemps/react-vocal'` resolves and returns a typed `triggerCommand` function.
- [ ] Visually verify the rendered README on GitHub shows the corrected examples.

## Notes
Pure additive runtime change. The two README example fixes preserve the visible API but correct the callback parameter naming to match what consumers actually receive at runtime. No breaking change.
