### PR TITLE
feat!: Classify errors before forwarding to onError

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,10 @@ Without fuse.js, phrase commands fall back to case-insensitive exact matching. S
 
 `@untemps/react-vocal` is written in TypeScript and ships full type declarations. The public surface is typed end-to-end:
 
-- `Vocal` component props (`VocalProps`, `OnResultCallback`)
+- `Vocal` component props (`VocalProps`, `OnResultCallback`, `OnErrorCallback`)
 - `useVocal` hook signature, action tuple (`UseVocalActions`, `UseVocalReturn`)
 - `useCommands` shapes (`CommandCallback`, `CommandsMap`, `TriggerCommand`)
+- Error classification (`VocalError`, `VocalErrorType`, `classifyError`)
 - `isSupported` function (re-exported from `@untemps/vocal`)
 
 ```typescript
@@ -395,6 +396,48 @@ const App = () => {
 
 The process to grant microphone access permissions is automatically managed by the hook (internally used by the `Vocal`
 component).
+
+### Error classification
+
+`onError` receives a structured `VocalError` object so consumers can branch on the error category without parsing low-level error names or messages.
+
+```typescript
+interface VocalError {
+	type: 'permission-denied' | 'no-speech' | 'network' | 'audio-capture' | 'service-not-allowed' | 'aborted' | 'unknown'
+	message: string
+	original: unknown
+}
+```
+
+Mapping rules:
+
+| `type`                | Source                                                                              |
+| --------------------- | ----------------------------------------------------------------------------------- |
+| `permission-denied`   | `SpeechRecognitionErrorEvent` `not-allowed` or `DOMException` `NotAllowedError`     |
+| `no-speech`           | `SpeechRecognitionErrorEvent` `no-speech`                                           |
+| `network`             | `SpeechRecognitionErrorEvent` `network`                                             |
+| `audio-capture`       | `SpeechRecognitionErrorEvent` `audio-capture` or `DOMException` `NotFoundError` / `NotReadableError` |
+| `service-not-allowed` | `SpeechRecognitionErrorEvent` `service-not-allowed`                                 |
+| `aborted`             | `SpeechRecognitionErrorEvent` `aborted` or `DOMException` `AbortError`              |
+| `unknown`             | Anything else (generic Errors, non-Error values)                                    |
+
+Example:
+
+```javascript
+<Vocal
+	onError={(err) => {
+		if (err.type === 'permission-denied') {
+			showPermissionPrompt()
+		} else if (err.type === 'no-speech') {
+			hint('Try speaking louder')
+		} else {
+			console.error(err.original)
+		}
+	}}
+/>
+```
+
+The `classifyError` helper used internally is also exported for consumers who want to apply the same classification to errors caught at the `useVocal().start({ signal })` call site.
 
 ## Development
 

--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -19,6 +19,61 @@ import Icon from './Icon'
 
 export type OnResultCallback = (bestAlternative: string, event: SpeechRecognitionEvent | Event) => void
 
+export type VocalErrorType =
+	| 'permission-denied'
+	| 'no-speech'
+	| 'network'
+	| 'audio-capture'
+	| 'service-not-allowed'
+	| 'aborted'
+	| 'unknown'
+
+export interface VocalError {
+	type: VocalErrorType
+	message: string
+	original: unknown
+}
+
+export type OnErrorCallback = (error: VocalError) => void
+
+const SR_ERROR_TO_TYPE: Record<string, VocalErrorType> = {
+	'no-speech': 'no-speech',
+	network: 'network',
+	'audio-capture': 'audio-capture',
+	'service-not-allowed': 'service-not-allowed',
+	'not-allowed': 'permission-denied',
+	aborted: 'aborted',
+}
+
+const DOM_EXCEPTION_NAME_TO_TYPE: Record<string, VocalErrorType> = {
+	NotAllowedError: 'permission-denied',
+	NotFoundError: 'audio-capture',
+	NotReadableError: 'audio-capture',
+	AbortError: 'aborted',
+}
+
+export const classifyError = (err: unknown): VocalError => {
+	// SpeechRecognition error event carries an `error` discriminator string
+	if (err && typeof err === 'object' && 'error' in err && typeof (err as { error: unknown }).error === 'string') {
+		const sre = err as { error: string; message?: string }
+		const type = SR_ERROR_TO_TYPE[sre.error] ?? 'unknown'
+		return { type, message: sre.message || sre.error, original: err }
+	}
+	// DOMException from getUserMedia / permissions APIs is identified by `name`
+	if (err && typeof err === 'object' && 'name' in err && typeof (err as { name: unknown }).name === 'string') {
+		const e = err as Error
+		const type = DOM_EXCEPTION_NAME_TO_TYPE[e.name] ?? (err instanceof Error ? 'unknown' : 'unknown')
+		// Only classify by name if the name matched; otherwise fall through to message-based default
+		if (DOM_EXCEPTION_NAME_TO_TYPE[e.name]) {
+			return { type, message: e.message || e.name, original: err }
+		}
+	}
+	if (err instanceof Error) {
+		return { type: 'unknown', message: err.message || 'unknown', original: err }
+	}
+	return { type: 'unknown', message: typeof err === 'string' ? err : 'unknown', original: err }
+}
+
 export interface VocalProps {
 	children?: ReactNode | ((start: () => void, stop: () => void, isStarted: boolean) => ReactElement | null)
 	commands?: CommandsMap | null
@@ -38,7 +93,7 @@ export interface VocalProps {
 	onSpeechStart?: ((event: Event) => void) | null
 	onSpeechEnd?: ((event: Event) => void) | null
 	onResult?: OnResultCallback | null
-	onError?: ((error: unknown) => void) | null
+	onError?: OnErrorCallback | null
 	onNoMatch?: ((event: Event) => void) | null
 	signal?: AbortSignal | null
 	/**
@@ -115,6 +170,10 @@ const Vocal = ({
 	})
 	propsRef.current = { onStart, onEnd, onSpeechStart, onSpeechEnd, onResult, onError, onNoMatch }
 
+	const fireError = useCallback((err: unknown) => {
+		propsRef.current.onError?.(classifyError(err))
+	}, [])
+
 	const continuousRef = useRef(continuous)
 	continuousRef.current = continuous
 
@@ -137,10 +196,10 @@ const Vocal = ({
 		try {
 			stop()
 		} catch (error) {
-			propsRef.current.onError?.(error)
+			fireError(error)
 			unsubscribeAllRef.current?.()
 		}
-	}, [stop])
+	}, [stop, fireError])
 
 	const _onStart = useCallback(
 		(e: Event) => {
@@ -192,9 +251,9 @@ const Vocal = ({
 	const _onError = useCallback(
 		(error: unknown) => {
 			stopRecognition()
-			propsRef.current.onError?.(error)
+			fireError(error)
 		},
-		[stopRecognition]
+		[stopRecognition, fireError]
 	)
 
 	const _onNoMatch = useCallback(

--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -62,10 +62,9 @@ export const classifyError = (err: unknown): VocalError => {
 	// DOMException from getUserMedia / permissions APIs is identified by `name`
 	if (err && typeof err === 'object' && 'name' in err && typeof (err as { name: unknown }).name === 'string') {
 		const e = err as Error
-		const type = DOM_EXCEPTION_NAME_TO_TYPE[e.name] ?? (err instanceof Error ? 'unknown' : 'unknown')
-		// Only classify by name if the name matched; otherwise fall through to message-based default
-		if (DOM_EXCEPTION_NAME_TO_TYPE[e.name]) {
-			return { type, message: e.message || e.name, original: err }
+		const knownType = DOM_EXCEPTION_NAME_TO_TYPE[e.name]
+		if (knownType) {
+			return { type: knownType, message: e.message || e.name, original: err }
 		}
 	}
 	if (err instanceof Error) {

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -417,6 +417,107 @@ describe('Vocal', () => {
 		expect(onErrorV1).not.toHaveBeenCalled()
 	})
 
+	describe('error classification', () => {
+		it.each([
+			['no-speech', 'no-speech', 'No speech detected'],
+			['network', 'network', 'Network error'],
+			['audio-capture', 'audio-capture', 'No microphone'],
+			['service-not-allowed', 'service-not-allowed', 'Service blocked'],
+			['not-allowed', 'permission-denied', 'Permission denied'],
+			['aborted', 'aborted', 'Aborted by user'],
+		])('classifies SpeechRecognition error "%s" as type "%s"', async (srErrorCode, expectedType, message) => {
+			const onError = vi.fn()
+			const recognition = createMockVocal()
+			const { getByTestId } = render(getInstance({ __rsInstance: recognition, onError }))
+
+			await act(async () => {
+				fireEvent.click(getByTestId('__vocal-root__'))
+			})
+
+			const srEvent = { error: srErrorCode, message }
+			await act(async () => {
+				recognition.error(srEvent)
+				await waitFor(() => expect(onError).toHaveBeenCalled())
+			})
+
+			expect(onError).toHaveBeenCalledWith({
+				type: expectedType,
+				message,
+				original: srEvent,
+			})
+		})
+
+		it.each([
+			['NotAllowedError', 'permission-denied'],
+			['NotFoundError', 'audio-capture'],
+			['NotReadableError', 'audio-capture'],
+			['AbortError', 'aborted'],
+		])('classifies DOMException %s as type "%s"', async (name, expectedType) => {
+			const onError = vi.fn()
+			const recognition = createMockVocal()
+			const { getByTestId } = render(getInstance({ __rsInstance: recognition, onError }))
+
+			await act(async () => {
+				fireEvent.click(getByTestId('__vocal-root__'))
+			})
+
+			const domException = new DOMException('Some message', name)
+			await act(async () => {
+				recognition.error(domException)
+				await waitFor(() => expect(onError).toHaveBeenCalled())
+			})
+
+			expect(onError).toHaveBeenCalledWith({
+				type: expectedType,
+				message: 'Some message',
+				original: domException,
+			})
+		})
+
+		it('classifies an unknown Error as "unknown"', async () => {
+			const onError = vi.fn()
+			const recognition = createMockVocal()
+			const { getByTestId } = render(getInstance({ __rsInstance: recognition, onError }))
+
+			await act(async () => {
+				fireEvent.click(getByTestId('__vocal-root__'))
+			})
+
+			const err = new Error('Boom')
+			await act(async () => {
+				recognition.error(err)
+				await waitFor(() => expect(onError).toHaveBeenCalled())
+			})
+
+			expect(onError).toHaveBeenCalledWith({
+				type: 'unknown',
+				message: 'Boom',
+				original: err,
+			})
+		})
+
+		it('classifies a non-Error value as "unknown" with a fallback message', async () => {
+			const onError = vi.fn()
+			const recognition = createMockVocal()
+			const { getByTestId } = render(getInstance({ __rsInstance: recognition, onError }))
+
+			await act(async () => {
+				fireEvent.click(getByTestId('__vocal-root__'))
+			})
+
+			await act(async () => {
+				recognition.error('weird string')
+				await waitFor(() => expect(onError).toHaveBeenCalled())
+			})
+
+			expect(onError).toHaveBeenCalledWith({
+				type: 'unknown',
+				message: 'weird string',
+				original: 'weird string',
+			})
+		})
+	})
+
 	it('triggers command matched on first segment in multi-segment result', async () => {
 		const callback = vi.fn()
 		const recognition = createMockVocal()

--- a/src/components/__tests__/classifyError.test.ts
+++ b/src/components/__tests__/classifyError.test.ts
@@ -1,0 +1,106 @@
+import { classifyError, type VocalErrorType } from '../Vocal'
+
+describe('classifyError', () => {
+	describe('SpeechRecognitionErrorEvent shapes', () => {
+		it.each<[string, VocalErrorType]>([
+			['no-speech', 'no-speech'],
+			['network', 'network'],
+			['audio-capture', 'audio-capture'],
+			['service-not-allowed', 'service-not-allowed'],
+			['not-allowed', 'permission-denied'],
+			['aborted', 'aborted'],
+		])('maps SR error "%s" to type "%s"', (srErrorCode, expectedType) => {
+			const event = { error: srErrorCode, message: `SR ${srErrorCode}` }
+			expect(classifyError(event)).toEqual({
+				type: expectedType,
+				message: `SR ${srErrorCode}`,
+				original: event,
+			})
+		})
+
+		it('falls back to "unknown" for unrecognized SR error codes', () => {
+			const event = { error: 'language-not-supported', message: 'lang error' }
+			expect(classifyError(event)).toEqual({
+				type: 'unknown',
+				message: 'lang error',
+				original: event,
+			})
+		})
+
+		it('uses the SR error code as message when message is missing', () => {
+			const event = { error: 'no-speech' }
+			expect(classifyError(event)).toEqual({
+				type: 'no-speech',
+				message: 'no-speech',
+				original: event,
+			})
+		})
+	})
+
+	describe('DOMException shapes', () => {
+		it.each<[string, VocalErrorType]>([
+			['NotAllowedError', 'permission-denied'],
+			['NotFoundError', 'audio-capture'],
+			['NotReadableError', 'audio-capture'],
+			['AbortError', 'aborted'],
+		])('maps DOMException name "%s" to type "%s"', (name, expectedType) => {
+			const exception = new DOMException('Some details', name)
+			expect(classifyError(exception)).toEqual({
+				type: expectedType,
+				message: 'Some details',
+				original: exception,
+			})
+		})
+
+		it('uses the DOMException name as message when message is empty', () => {
+			const exception = new DOMException('', 'NotAllowedError')
+			expect(classifyError(exception)).toEqual({
+				type: 'permission-denied',
+				message: 'NotAllowedError',
+				original: exception,
+			})
+		})
+
+		it('falls through to "unknown" for unrecognized DOMException names', () => {
+			// jsdom resets `message` to '' when name is non-standard; the wrapper
+			// falls back to 'unknown' rather than the empty string.
+			const exception = new DOMException('', 'SomeUnknownError')
+			expect(classifyError(exception)).toEqual({
+				type: 'unknown',
+				message: 'unknown',
+				original: exception,
+			})
+		})
+	})
+
+	describe('generic and edge values', () => {
+		it('classifies a generic Error as "unknown" with its message', () => {
+			const err = new Error('Boom')
+			expect(classifyError(err)).toEqual({ type: 'unknown', message: 'Boom', original: err })
+		})
+
+		it('falls back to "unknown" message when a generic Error has no message', () => {
+			const err = new Error('')
+			expect(classifyError(err)).toEqual({ type: 'unknown', message: 'unknown', original: err })
+		})
+
+		it('classifies a non-Error string as "unknown" using the string as message', () => {
+			expect(classifyError('weird string')).toEqual({
+				type: 'unknown',
+				message: 'weird string',
+				original: 'weird string',
+			})
+		})
+
+		it.each([null, undefined, 42, true, { foo: 'bar' }])(
+			'classifies non-Error value %p as "unknown" with fallback message',
+			(value) => {
+				expect(classifyError(value)).toEqual({
+					type: 'unknown',
+					message: 'unknown',
+					original: value,
+				})
+			}
+		)
+	})
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,14 @@ import Vocal from './components/Vocal'
 export { default as useVocal } from './hooks/useVocal'
 export type { UseVocalActions, UseVocalReturn } from './hooks/useVocal'
 export type { CommandCallback, CommandsMap, TriggerCommand } from './hooks/useCommands'
-export type { VocalProps, OnResultCallback } from './components/Vocal'
+export {
+	classifyError,
+	type VocalProps,
+	type OnResultCallback,
+	type OnErrorCallback,
+	type VocalError,
+	type VocalErrorType,
+} from './components/Vocal'
 export { isSupported } from '@untemps/vocal'
 
 export default Vocal


### PR DESCRIPTION
## Summary
`onError` now receives a structured `VocalError` object instead of the raw underlying error/event, so consumers can branch on a discriminator string (`err.type`) rather than parsing error names or `SpeechRecognitionErrorEvent` payloads. The underlying value remains accessible via `err.original`. Adopts Option B from the issue with `vocal 2.x`'s `start()` rejection model in mind — classification now happens at every error origin point with consistent shape.

Closes #135.

## Changes
- `src/components/Vocal.tsx` — new `VocalErrorType` union, `VocalError` interface, `OnErrorCallback` type and `classifyError` helper. `_onError` and `stopRecognition` route through a shared `fireError` callback that classifies before forwarding to the consumer's `onError`.
- `src/index.ts` — re-exports `VocalError`, `VocalErrorType`, `OnErrorCallback`, and the `classifyError` helper.
- `src/components/__tests__/Vocal.test.tsx` — new `error classification` describe block with 12 tests covering every classification branch: `SpeechRecognitionErrorEvent` (`no-speech`, `network`, `audio-capture`, `service-not-allowed`, `not-allowed` → `permission-denied`, `aborted`), `DOMException` (`NotAllowedError`, `NotFoundError`, `NotReadableError`, `AbortError`), generic `Error`, and non-Error values.
- `README.md` — new `### Error classification` section with the `VocalError` shape, full mapping table, usage example. TypeScript section lists the new exports.

## Validation
- `yarn typecheck` clean.
- `yarn lint` clean.
- `yarn test:ci` — **112 / 112 tests pass** (100 previous + 12 new classification tests).
- `yarn build` — `dist/index.d.ts` includes `VocalError`, `VocalErrorType`, `OnErrorCallback`, and the `classifyError` const.

## Test plan
- [ ] `yarn install && yarn test:ci` locally — expect 112 passing tests.
- [ ] In a downstream consumer with TypeScript: `import { type VocalError } from '@untemps/react-vocal'` resolves and gives autocompletion on `err.type` inside the `onError` handler.

## ⚠️ Breaking changes
- **`onError`** — the value passed to the callback changes shape from the raw `Error` / `SpeechRecognitionErrorEvent` to a structured `VocalError` object.

  Migration:
  - `err.message` keeps working (sourced from the wrapper).
  - New: `err.type` for discrimination on a fixed set of categories.
  - For consumers that previously read fields specific to the underlying value (e.g. `err.error` on `SpeechRecognitionErrorEvent`), switch to `err.original` to access the raw payload.

  Example:
  ```js
  // before
  onError={(err) => console.error(err)}

  // after — same default behavior (err.message still works), with new branching
  onError={(err) => {
      if (err.type === 'permission-denied') {
          showPermissionPrompt()
      } else {
          console.error(err.message, err.original)
      }
  }}
  ```