### PR TITLE
docs: Align README Node requirement with package.json engines.node

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Although the lack of `SpeechGrammar` and `SpeechGrammarList` is handled by the u
 ## Requirements
 
 -   React >= 16.13.1
--   Node >= 20.19.0
+-   Node >= 22
 
 ## Installation
 


### PR DESCRIPTION
## Summary

`README.md:43` advertised `Node >= 20.19.0`, but `package.json` `engines.node` is `">=22"` and was explicitly bumped to `>=22` as a BREAKING CHANGE in 2.0.0-beta.15 (#156). The README is now aligned with the actual requirement.

## Changes

- `README.md` — replaced `Node >= 20.19.0` with `Node >= 22` (line 43).

## Test plan

- [x] `yarn typecheck` — passes
- [x] `yarn lint` — passes
- [x] `yarn test:ci` — 133/133 tests pass
- [x] `yarn build` — succeeds (existing MIXED_EXPORTS warning unrelated, tracked in #166)
- [ ] Reviewer confirms the README phrasing fits the rest of the Requirements section

Closes #162