### PR TITLE
fix: Reset isRecording when start() rejects or silently aborts

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ const [, { start }] = useVocal('en-US')
 start({ signal: controller.signal })
 ```
 
-**Behavior note** — the underlying `@untemps/vocal` library currently swallows the `AbortError` internally: the promise returned by `start()` resolves silently rather than rejecting (see [untemps/vocal#129](https://github.com/untemps/vocal/issues/129)). `react-vocal` compensates by detecting `signal.aborted` after resolution and rolling `isRecording` back to `false`, so consumers of `<Vocal>` or `useVocal` do not need any extra handling. If you call `vocal.start()` directly (bypassing `useVocal`), you must check `signal.aborted` yourself.
+**Behavior note** — the underlying `@untemps/vocal` library currently swallows the `AbortError` internally: the promise returned by `start()` resolves silently rather than rejecting (see [untemps/vocal#129](https://github.com/untemps/vocal/issues/129)). `react-vocal` compensates by detecting `signal.aborted` after resolution and rolling `isRecording` back to `false`, so consumers of `<Vocal>` or `useVocal` do not need any extra handling. If you bypass the hook and access the underlying `VocalInstance` via the ref returned by `useVocal`, you must check `signal.aborted` yourself after `start()` resolves.
 
 ### `useCommands` hook
 

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ const [ref, { start, stop, abort, subscribe, unsubscribe, clean, isRecording }]
 
 #### Cancelling a start in flight
 
-Both `<Vocal signal={...}>` and `useVocal().start({ signal })` accept an `AbortSignal`. Aborting the controller while the browser is still resolving microphone permission cancels the start cleanly — no `start` event is dispatched.
+Both `<Vocal signal={...}>` and `useVocal().start({ signal })` accept an `AbortSignal`. Aborting the controller while the browser is still resolving microphone permission cancels the start cleanly — no `start` event is dispatched and `isRecording` reverts to `false`.
 
 ```javascript
 const controller = new AbortController()
@@ -361,6 +361,8 @@ setTimeout(() => controller.abort(), 2000)
 const [, { start }] = useVocal('en-US')
 start({ signal: controller.signal })
 ```
+
+**Behavior note** — the underlying `@untemps/vocal` library currently swallows the `AbortError` internally: the promise returned by `start()` resolves silently rather than rejecting (see [untemps/vocal#129](https://github.com/untemps/vocal/issues/129)). `react-vocal` compensates by detecting `signal.aborted` after resolution and rolling `isRecording` back to `false`, so consumers of `<Vocal>` or `useVocal` do not need any extra handling. If you call `vocal.start()` directly (bypassing `useVocal`), you must check `signal.aborted` yourself.
 
 ### `useCommands` hook
 

--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -300,9 +300,9 @@ const Vocal = ({
 		try {
 			stopSilenceTimer()
 			Object.entries(HANDLERS).forEach(([event, fn]) => subscribe(event, fn as (e: Event) => void))
-			// vocal 2.x rejects on microphone/permission errors — catch the async
-			// rejection so it doesn't surface as an UnhandledPromiseRejection.
-			start({ signal: signal ?? undefined })?.catch?.(_onError)
+			// useVocal's start() rejects on microphone/permission errors — catch
+			// the async rejection so it doesn't surface as an UnhandledPromiseRejection.
+			start({ signal: signal ?? undefined }).catch(_onError)
 		} catch (error) {
 			_onError(error)
 		}

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -680,6 +680,19 @@ describe('Vocal', () => {
 		expect(onStart).not.toHaveBeenCalled()
 	})
 
+	it('reverts aria-pressed to false when the signal prop is already aborted', async () => {
+		const controller = new AbortController()
+		controller.abort()
+		const { getByTestId } = render(getInstance({ signal: controller.signal }))
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+			await new Promise((r) => setTimeout(r, 50))
+		})
+
+		expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-pressed', 'false')
+	})
+
 	it('calls onEnd via the end event when stop is asynchronous', async () => {
 		const onEnd = vi.fn()
 		const recognition = createMockVocal()

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -681,9 +681,10 @@ describe('Vocal', () => {
 	})
 
 	it('reverts aria-pressed to false when the signal prop is already aborted', async () => {
+		const onError = vi.fn()
 		const controller = new AbortController()
 		controller.abort()
-		const { getByTestId } = render(getInstance({ signal: controller.signal }))
+		const { getByTestId } = render(getInstance({ signal: controller.signal, onError }))
 
 		await act(async () => {
 			fireEvent.click(getByTestId('__vocal-root__'))
@@ -691,6 +692,9 @@ describe('Vocal', () => {
 		})
 
 		expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-pressed', 'false')
+		// Silent abort is not an error from the consumer's perspective —
+		// no error event should surface.
+		expect(onError).not.toHaveBeenCalled()
 	})
 
 	it('calls onEnd via the end event when stop is asynchronous', async () => {

--- a/src/hooks/__tests__/useVocal.test.ts
+++ b/src/hooks/__tests__/useVocal.test.ts
@@ -209,13 +209,21 @@ describe('useVocal', () => {
 			})
 			const { result } = renderHook(() => useVocal())
 			await act(async () => {
-				try {
-					result.current[1].start()
-				} catch {
-					/* swallow */
-				}
+				expect(() => result.current[1].start()).toThrow('boom')
 			})
 			expect(result.current[1].isRecording).toBe(false)
+		})
+
+		it('keeps isRecording true when start() resolves and the signal is not aborted', async () => {
+			// Guard against regression: the post-hoc abort detection must not fire
+			// on a normal successful start.
+			mockStart.mockReturnValue(Promise.resolve())
+			const controller = new AbortController() // not aborted
+			const { result } = renderHook(() => useVocal())
+			await act(async () => {
+				await result.current[1].start({ signal: controller.signal })
+			})
+			expect(result.current[1].isRecording).toBe(true)
 		})
 
 		it('triggers stop function', () => {

--- a/src/hooks/__tests__/useVocal.test.ts
+++ b/src/hooks/__tests__/useVocal.test.ts
@@ -206,13 +206,15 @@ describe('useVocal', () => {
 			expect(result.current[1].isRecording).toBe(false)
 		})
 
-		it('flips isRecording back to false when start() throws synchronously', async () => {
+		it('flips isRecording back to false when vocal.start() throws synchronously', async () => {
+			// vocal.start() throwing synchronously is caught by the async wrapper
+			// and surfaces as a rejected promise — the rollback still applies.
 			mockStart.mockImplementation(() => {
 				throw new Error('boom')
 			})
 			const { result } = renderHook(() => useVocal())
 			await act(async () => {
-				expect(() => result.current[1].start()).toThrow('boom')
+				await expect(result.current[1].start()).rejects.toThrow('boom')
 			})
 			expect(result.current[1].isRecording).toBe(false)
 		})

--- a/src/hooks/__tests__/useVocal.test.ts
+++ b/src/hooks/__tests__/useVocal.test.ts
@@ -103,6 +103,9 @@ describe('useVocal', () => {
 			mockOn.mockReset()
 			mockOff.mockReset()
 			mockCleanup.mockReset()
+			// vocal 2.x's start() always returns a Promise — default the mock to
+			// match the real contract so tests don't have to opt in every time.
+			mockStart.mockReturnValue(Promise.resolve())
 			vi.mocked(createVocal).mockImplementation(() => ({
 				start: mockStart,
 				stop: mockStop,
@@ -224,6 +227,47 @@ describe('useVocal', () => {
 				await result.current[1].start({ signal: controller.signal })
 			})
 			expect(result.current[1].isRecording).toBe(true)
+		})
+
+		it('keeps isRecording true when the start event fires and the signal aborts late', async () => {
+			// Race scenario: vocal.start() succeeds (the real 'start' event has
+			// already been dispatched), then the consumer aborts the signal
+			// before the wrapper's .then microtask runs. The rollback must rely
+			// on whether 'start' actually fired, not just on signal.aborted, so
+			// the real-recording flag stays `true`.
+			let resolveStart: (() => void) | undefined
+			mockStart.mockReturnValue(
+				new Promise<void>((res) => {
+					resolveStart = res
+				})
+			)
+			const controller = new AbortController()
+			const { result } = renderHook(() => useVocal())
+			await act(async () => {
+				const p = result.current[1].start({ signal: controller.signal })
+				// Simulate vocal dispatching 'start' to every subscriber, including
+				// the wrapper's internal tracker.
+				mockOn.mock.calls
+					.filter(([type]) => type === 'start')
+					.forEach(([, handler]) => (handler as () => void)())
+				// Consumer aborts after recognition truly started.
+				controller.abort()
+				resolveStart?.()
+				await p
+			})
+			expect(result.current[1].isRecording).toBe(true)
+		})
+
+		it('unsubscribes the internal start tracker once the promise settles', async () => {
+			// Each start() call adds a transient 'start' listener used for the
+			// silent-abort detection. It must be removed once the promise settles
+			// so repeated calls do not leak listeners on the vocal instance.
+			mockStart.mockReturnValue(Promise.resolve())
+			const { result } = renderHook(() => useVocal())
+			await act(async () => {
+				await result.current[1].start()
+			})
+			expect(mockOff).toHaveBeenCalledWith('start', expect.any(Function))
 		})
 
 		it('triggers stop function', () => {

--- a/src/hooks/__tests__/useVocal.test.ts
+++ b/src/hooks/__tests__/useVocal.test.ts
@@ -94,12 +94,15 @@ describe('useVocal', () => {
 		})
 
 		beforeEach(() => {
-			mockStart.mockClear()
-			mockStop.mockClear()
-			mockAbort.mockClear()
-			mockOn.mockClear()
-			mockOff.mockClear()
-			mockCleanup.mockClear()
+			// mockReset clears both calls and any per-test implementation overrides
+			// (mockReturnValue / mockImplementation). mockClear would leak those overrides
+			// across tests — see the start() rejection / throw cases below.
+			mockStart.mockReset()
+			mockStop.mockReset()
+			mockAbort.mockReset()
+			mockOn.mockReset()
+			mockOff.mockReset()
+			mockCleanup.mockReset()
 			vi.mocked(createVocal).mockImplementation(() => ({
 				start: mockStart,
 				stop: mockStop,
@@ -157,15 +160,62 @@ describe('useVocal', () => {
 			expect(mockStart).toHaveBeenCalledWith({ signal: controller.signal })
 		})
 
-		it('returns the promise from the vocal start() call', () => {
-			const startPromise = Promise.resolve()
-			mockStart.mockReturnValue(startPromise)
+		it('returns a promise that resolves with the vocal start() value', async () => {
+			mockStart.mockReturnValue(Promise.resolve())
 			const {
 				result: {
 					current: [, { start }],
 				},
 			} = renderHook(() => useVocal())
-			expect(start()).toBe(startPromise)
+			await expect(start()).resolves.toBeUndefined()
+		})
+
+		it('propagates the rejection from vocal start() to the caller', async () => {
+			const err = new Error('mic denied')
+			mockStart.mockReturnValue(Promise.reject(err))
+			const {
+				result: {
+					current: [, { start }],
+				},
+			} = renderHook(() => useVocal())
+			await expect(start()).rejects.toBe(err)
+		})
+
+		it('flips isRecording back to false when start() rejects asynchronously', async () => {
+			mockStart.mockReturnValue(Promise.reject(new Error('aborted')))
+			const { result } = renderHook(() => useVocal())
+			await act(async () => {
+				await result.current[1].start()?.catch(() => {})
+			})
+			expect(result.current[1].isRecording).toBe(false)
+		})
+
+		it('flips isRecording back to false when start() silently resolves with an aborted signal', async () => {
+			// vocal 2.x swallows AbortError internally — start() resolves without
+			// dispatching 'start'. Detect the post-hoc abort and reset the flag.
+			mockStart.mockReturnValue(Promise.resolve())
+			const controller = new AbortController()
+			controller.abort()
+			const { result } = renderHook(() => useVocal())
+			await act(async () => {
+				await result.current[1].start({ signal: controller.signal })
+			})
+			expect(result.current[1].isRecording).toBe(false)
+		})
+
+		it('flips isRecording back to false when start() throws synchronously', async () => {
+			mockStart.mockImplementation(() => {
+				throw new Error('boom')
+			})
+			const { result } = renderHook(() => useVocal())
+			await act(async () => {
+				try {
+					result.current[1].start()
+				} catch {
+					/* swallow */
+				}
+			})
+			expect(result.current[1].isRecording).toBe(false)
 		})
 
 		it('triggers stop function', () => {

--- a/src/hooks/useVocal.ts
+++ b/src/hooks/useVocal.ts
@@ -59,36 +59,45 @@ const useVocal = (
 	}, [lang, grammars, maxAlternatives, continuous, supported])
 
 	const start = useCallback((options?: { signal?: AbortSignal }): Promise<void> | undefined => {
-		if (!ref.current) return undefined
+		const instance = ref.current
+		if (!instance) return undefined
 		// Optimistic update so the UI reacts immediately at click, before the
 		// async permission/getUserMedia chain resolves and fires the 'start' event.
 		setIsRecording(true)
 		// vocal 2.x's start() can either reject (microphone/permission errors) or
 		// silently resolve without dispatching 'start' (AbortError on the signal —
 		// caught and swallowed internally). In both cases the instance never fires
-		// 'end'/'error', so the optimistic flag would stay stuck on `true`. Roll it
-		// back on rejection AND on silent abort, while preserving the original
-		// rejection so the caller's .catch still fires.
+		// 'end'/'error', so the optimistic flag would stay stuck on `true`.
+		//
+		// To distinguish a silent abort from a late abort that races a real
+		// success (consumer aborts the controller after the recognition truly
+		// started), track whether 'start' actually fired before rolling back.
 		const signal = options?.signal
-		let promise: Promise<void> | undefined
+		let startEventFired = false
+		const onceStart = () => {
+			startEventFired = true
+		}
+		instance.on('start', onceStart)
+		const unbind = () => instance.off('start', onceStart)
+		let promise: Promise<void>
 		try {
-			promise = ref.current.start(options)
+			promise = instance.start(options)
 		} catch (err) {
+			unbind()
 			setIsRecording(false)
 			throw err
 		}
-		if (promise && typeof promise.then === 'function') {
-			return promise.then(
+		return promise
+			.then(
 				() => {
-					if (signal?.aborted) setIsRecording(false)
+					if (!startEventFired && signal?.aborted) setIsRecording(false)
 				},
 				(err) => {
 					setIsRecording(false)
 					throw err
 				}
 			)
-		}
-		return promise
+			.finally(unbind)
 	}, [])
 
 	const stop = useCallback(() => {

--- a/src/hooks/useVocal.ts
+++ b/src/hooks/useVocal.ts
@@ -9,7 +9,7 @@ import {
 } from '@untemps/vocal'
 
 export interface UseVocalActions {
-	start: (options?: { signal?: AbortSignal }) => Promise<void> | undefined
+	start: (options?: { signal?: AbortSignal }) => Promise<void>
 	stop: () => void
 	abort: () => void
 	subscribe: {
@@ -58,9 +58,9 @@ const useVocal = (
 		}
 	}, [lang, grammars, maxAlternatives, continuous, supported])
 
-	const start = useCallback((options?: { signal?: AbortSignal }): Promise<void> | undefined => {
+	const start = useCallback(async (options?: { signal?: AbortSignal }): Promise<void> => {
 		const instance = ref.current
-		if (!instance) return undefined
+		if (!instance) return
 		// Optimistic update so the UI reacts immediately at click, before the
 		// async permission/getUserMedia chain resolves and fires the 'start' event.
 		setIsRecording(true)
@@ -68,36 +68,22 @@ const useVocal = (
 		// silently resolve without dispatching 'start' (AbortError on the signal —
 		// caught and swallowed internally). In both cases the instance never fires
 		// 'end'/'error', so the optimistic flag would stay stuck on `true`.
-		//
-		// To distinguish a silent abort from a late abort that races a real
-		// success (consumer aborts the controller after the recognition truly
-		// started), track whether 'start' actually fired before rolling back.
-		const signal = options?.signal
+		// Track the real 'start' event so a late signal abort that races a true
+		// success doesn't trigger a false rollback.
 		let startEventFired = false
 		const onceStart = () => {
 			startEventFired = true
 		}
 		instance.on('start', onceStart)
-		const unbind = () => instance.off('start', onceStart)
-		let promise: Promise<void>
 		try {
-			promise = instance.start(options)
+			await instance.start(options)
+			if (!startEventFired && options?.signal?.aborted) setIsRecording(false)
 		} catch (err) {
-			unbind()
 			setIsRecording(false)
 			throw err
+		} finally {
+			instance.off('start', onceStart)
 		}
-		return promise
-			.then(
-				() => {
-					if (!startEventFired && signal?.aborted) setIsRecording(false)
-				},
-				(err) => {
-					setIsRecording(false)
-					throw err
-				}
-			)
-			.finally(unbind)
 	}, [])
 
 	const stop = useCallback(() => {

--- a/src/hooks/useVocal.ts
+++ b/src/hooks/useVocal.ts
@@ -71,10 +71,10 @@ const useVocal = (
 		// Track the real 'start' event so a late signal abort that races a true
 		// success doesn't trigger a false rollback.
 		let startEventFired = false
-		const onceStart = () => {
+		const onStart = () => {
 			startEventFired = true
 		}
-		instance.on('start', onceStart)
+		instance.on('start', onStart)
 		try {
 			await instance.start(options)
 			if (!startEventFired && options?.signal?.aborted) setIsRecording(false)
@@ -82,7 +82,7 @@ const useVocal = (
 			setIsRecording(false)
 			throw err
 		} finally {
-			instance.off('start', onceStart)
+			instance.off('start', onStart)
 		}
 	}, [])
 

--- a/src/hooks/useVocal.ts
+++ b/src/hooks/useVocal.ts
@@ -63,9 +63,32 @@ const useVocal = (
 		// Optimistic update so the UI reacts immediately at click, before the
 		// async permission/getUserMedia chain resolves and fires the 'start' event.
 		setIsRecording(true)
-		// vocal 2.x's start() returns a Promise that rejects on microphone/permission
-		// errors. Returning it lets consumers await or attach a .catch handler.
-		return ref.current.start(options)
+		// vocal 2.x's start() can either reject (microphone/permission errors) or
+		// silently resolve without dispatching 'start' (AbortError on the signal —
+		// caught and swallowed internally). In both cases the instance never fires
+		// 'end'/'error', so the optimistic flag would stay stuck on `true`. Roll it
+		// back on rejection AND on silent abort, while preserving the original
+		// rejection so the caller's .catch still fires.
+		const signal = options?.signal
+		let promise: Promise<void> | undefined
+		try {
+			promise = ref.current.start(options)
+		} catch (err) {
+			setIsRecording(false)
+			throw err
+		}
+		if (promise && typeof promise.then === 'function') {
+			return promise.then(
+				() => {
+					if (signal?.aborted) setIsRecording(false)
+				},
+				(err) => {
+					setIsRecording(false)
+					throw err
+				}
+			)
+		}
+		return promise
 	}, [])
 
 	const stop = useCallback(() => {


### PR DESCRIPTION
## Summary

`useVocal().start()` (and therefore `<Vocal>`) used to leave `isRecording` stuck at `true` whenever the underlying `vocal.start()` call did not surface a normal `'start'` event. In particular, vocal 2.x **silently swallows** `AbortError` from an aborted signal — the promise resolves without dispatching `'start'`, and the optimistic `setIsRecording(true)` was never rolled back. The UI stayed in the "listening" state (`aria-pressed="true"`, default cursor, listening icon) indefinitely.

## Root cause

`useVocal.start` only set the flag optimistically. It relied on either the `'start'` or `'end'`/`'error'` events to keep it in sync, but neither fires when:
- The signal is already aborted at click time (vocal 2.x catches the `AbortError` internally and returns silently).
- `vocal.start()` rejects (e.g. permission denied) — `vocal.stop()` is a no-op when nothing started, so `'end'` never fires either.

## Changes

- `src/hooks/useVocal.ts` — wrap `vocal.start()` with an `async`/`await` block that:
  - Resets `isRecording` on rejection and rethrows the original error.
  - Subscribes a transient `'start'` listener and resets `isRecording` only if the promise resolves without that event firing **and** the signal is aborted — covers the vocal 2.x silent-abort path without false-rollbacking a late abort that races a real success.
  - Always unsubscribes the transient listener via `finally`.
  - Return type tightened from `Promise<void> | undefined` to `Promise<void>` (the unsupported branch now resolves with `undefined` instead of returning `undefined`).
- `src/components/Vocal.tsx` — drop the now-redundant `?.catch?.` chaining on the `start()` call.
- `src/hooks/__tests__/useVocal.test.ts`:
  - Replaced the implementation-coupled `returns the promise from the vocal start() call` test with assertions on observable behavior (resolution value + rejection propagation).
  - Added regression tests for the rollback paths (async rejection, silent abort, sync throw) **and** the non-regression cases (normal success, race between real start event and late abort, listener cleanup on settle).
  - Switched the `beforeEach` from `mockClear()` to `mockReset()` so per-test `mockImplementation` overrides no longer leak between tests; defaulted `mockStart` to a resolved promise to match vocal 2.x's real contract.
- `src/components/__tests__/Vocal.test.tsx` — added a sibling test to the existing aborted-signal case that asserts `aria-pressed` reverts to `false`.
- `README.md` — documented the upstream silent-abort workaround in the *Cancelling a start in flight* section.

## Test plan

- [x] `yarn typecheck` — passes
- [x] `yarn lint` — passes
- [x] `yarn test:ci` — 141/141 tests pass (7 new in useVocal, 1 new in Vocal); coverage 98.36 % statements
- [x] `yarn build` — succeeds (existing MIXED_EXPORTS warning unrelated, tracked in #166)
- [x] Manual: `cd dev && yarn dev` boots without error

## Notes

- The promise returned by `useVocal().start(...)` is no longer the *identical* reference returned by `vocal.start()` — it is now a wrapped promise. The public contract (resolves on success, rejects with the same error on failure) is preserved.
- The `start` type signature is now `Promise<void>` (no `| undefined`). A synchronous throw from the underlying `vocal.start()` is caught by the async wrapper and surfaces as a rejected promise. Both are strictly more permissive for callers using `await` or `.catch()`, so existing consumers continue to work.

Closes #163
