### PR TITLE
chore: silenceTimeout test does not actually exercise the silence timer

### DIFF
--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -819,8 +819,18 @@ describe('Vocal', () => {
 			const onEnd = vi.fn()
 			const onResult = vi.fn()
 			const recognition = createMockVocal({ continuous: true })
+			// timeout bumped above silenceTimeout so the regular timer cannot fire first —
+			// both timers share stableTimerCb, so a shorter `timeout` would mask which one
+			// actually triggered _onEnd.
 			const { getByTestId } = render(
-				getInstance({ __rsInstance: recognition, onEnd, onResult, continuous: true, silenceTimeout: 5000 })
+				getInstance({
+					__rsInstance: recognition,
+					onEnd,
+					onResult,
+					continuous: true,
+					timeout: 10_000,
+					silenceTimeout: 5000,
+				})
 			)
 
 			await act(async () => {
@@ -833,8 +843,15 @@ describe('Vocal', () => {
 
 			expect(onEnd).not.toHaveBeenCalled()
 
+			// Just before the silence threshold — neither timer should have fired.
 			act(() => {
-				vi.advanceTimersByTime(5000)
+				vi.advanceTimersByTime(4999)
+			})
+			expect(onEnd).not.toHaveBeenCalled()
+
+			// Crossing the silenceTimeout boundary is what fires _onEnd.
+			act(() => {
+				vi.advanceTimersByTime(1)
 			})
 
 			expect(onEnd).toHaveBeenCalledTimes(1)

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -843,13 +843,11 @@ describe('Vocal', () => {
 
 			expect(onEnd).not.toHaveBeenCalled()
 
-			// Just before the silence threshold — neither timer should have fired.
 			act(() => {
 				vi.advanceTimersByTime(4999)
 			})
 			expect(onEnd).not.toHaveBeenCalled()
 
-			// Crossing the silenceTimeout boundary is what fires _onEnd.
 			act(() => {
 				vi.advanceTimersByTime(1)
 			})
@@ -861,9 +859,6 @@ describe('Vocal', () => {
 		})
 
 		it('does not start the silence timer when continuous is false', async () => {
-			// Regression for #164: the silenceTimeout branch in _onSpeechEnd is gated on
-			// continuousRef.current. With continuous=false, providing silenceTimeout must
-			// not arm a silence timer — only the regular `timeout` is in effect.
 			vi.useFakeTimers()
 			const onEnd = vi.fn()
 			const recognition = createMockVocal()
@@ -889,8 +884,6 @@ describe('Vocal', () => {
 				recognition.fire('speechend', new Event('speechend'))
 			})
 
-			// Past silenceTimeout, before the regular timeout. If the silence timer
-			// had wrongly armed, _onEnd would fire here.
 			act(() => {
 				vi.advanceTimersByTime(5000)
 			})

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -859,6 +859,45 @@ describe('Vocal', () => {
 			expect(onResult).toHaveBeenCalledWith('Hello', expect.anything())
 			vi.useRealTimers()
 		})
+
+		it('does not start the silence timer when continuous is false', async () => {
+			// Regression for #164: the silenceTimeout branch in _onSpeechEnd is gated on
+			// continuousRef.current. With continuous=false, providing silenceTimeout must
+			// not arm a silence timer — only the regular `timeout` is in effect.
+			vi.useFakeTimers()
+			const onEnd = vi.fn()
+			const recognition = createMockVocal()
+			const { getByTestId } = render(
+				getInstance({
+					__rsInstance: recognition,
+					onEnd,
+					continuous: false,
+					timeout: 10_000,
+					silenceTimeout: 5000,
+				})
+			)
+
+			await act(async () => {
+				fireEvent.click(getByTestId('__vocal-root__'))
+			})
+
+			// Drive speechstart/speechend directly — a full say() would emit `result`,
+			// which in non-continuous mode calls stopRecognition() and fires `end`
+			// immediately, masking the silence-timer branch under test.
+			act(() => {
+				recognition.fire('speechstart', new Event('speechstart'))
+				recognition.fire('speechend', new Event('speechend'))
+			})
+
+			// Past silenceTimeout, before the regular timeout. If the silence timer
+			// had wrongly armed, _onEnd would fire here.
+			act(() => {
+				vi.advanceTimersByTime(5000)
+			})
+
+			expect(onEnd).not.toHaveBeenCalled()
+			vi.useRealTimers()
+		})
 	})
 
 	it('triggers onError handler when subscribe throws', async () => {


### PR DESCRIPTION
## Summary

The existing test `auto-stops after silenceTimeout ms of inactivity following last result` (`Vocal.test.tsx:817`) was passing for the wrong reason. It left the regular `timeout` at its default `3000ms` while asserting auto-stop after `5000ms` of silence. Both timers share `stableTimerCb`, so the 3000ms regular timer fired first — the `silenceTimeout` branch in `_onSpeechEnd` (`Vocal.tsx:218`) was never the actual trigger.

## Changes

- **Rewrite** the test to bump `timeout: 10_000` (above `silenceTimeout`) and advance fake timers in two steps (`4999ms` then `+1ms`). Asserting `onEnd` is silent before the silence threshold and fires exactly at it proves the silence timer is the cause, not the regular one.
- **Add** a regression test (`does not start the silence timer when continuous is false`) that drives `speechstart`/`speechend` directly in non-continuous mode (a full `say()` would trigger `_onResult` → immediate stop, masking the branch under test), advances past the silence threshold, and asserts `onEnd` was not called — locking in the `continuousRef.current` gate from `Vocal.tsx:218`.

## Test plan

- [x] `yarn test:ci` — 142/142 passing (+1 new test)
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn build`
- [x] Manual: `cd dev && yarn dev` boots without error

Closes #164