### PR TITLE
refactor!: Switch to named-only exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,24 @@ yarn add fuse.js
 
 Without fuse.js, phrase commands fall back to case-insensitive exact matching. Single-word commands always use exact matching and never require fuse.js.
 
+## Migration from 1.x
+
+`@untemps/react-vocal` 2.x exposes a single named-export surface — there is no longer a default export. Every entry point must be imported with braces:
+
+```diff
+- import Vocal from '@untemps/react-vocal'
++ import { Vocal } from '@untemps/react-vocal'
+```
+
+CJS consumers must update the destructuring accordingly:
+
+```diff
+- const { default: Vocal } = require('@untemps/react-vocal')
++ const { Vocal } = require('@untemps/react-vocal')
+```
+
+This removes the Rollup `MIXED_EXPORTS` warning from the build and aligns the ESM and CJS shapes — both now expose `Vocal`, `useVocal`, `useCommands`, `isSupported`, and `classifyError` as named exports.
+
 ## TypeScript
 
 `@untemps/react-vocal` is written in TypeScript and ships full type declarations. The public surface is typed end-to-end:
@@ -67,7 +85,7 @@ Without fuse.js, phrase commands fall back to case-insensitive exact matching. S
 - `isSupported` function (re-exported from `@untemps/vocal`)
 
 ```typescript
-import Vocal, { useVocal, isSupported, type VocalProps, type CommandsMap } from '@untemps/react-vocal'
+import { Vocal, useVocal, isSupported, type VocalProps, type CommandsMap } from '@untemps/react-vocal'
 ```
 
 TypeScript is listed as an optional peer dependency (`>=6.0.0`) — install it only if your project uses TS.
@@ -79,7 +97,7 @@ TypeScript is listed as an optional peer dependency (`>=6.0.0`) — install it o
 #### Basic usage
 
 ```javascript
-import Vocal from '@untemps/react-vocal'
+import { Vocal } from '@untemps/react-vocal'
 
 const App = () => {
 	const [result, setResult] = useState('')
@@ -123,7 +141,7 @@ But you can provide your own component.
 -   With a simple React element:
 
 ```javascript
-import Vocal from '@untemps/react-vocal'
+import { Vocal } from '@untemps/react-vocal'
 
 const App = () => {
 	return (
@@ -141,7 +159,7 @@ hierarchy, use the function syntax below.
 -   With a function that returns a React element:
 
 ```javascript
-import Vocal from '@untemps/react-vocal'
+import { Vocal } from '@untemps/react-vocal'
 
 const Play = () => (
 	<div
@@ -422,7 +440,7 @@ Matching rules:
 `isSupported` is a function that returns `true` when the browser supports the Web Speech API (along with the Permissions and MediaDevices APIs that `@untemps/vocal` relies on). It is safe to call during server-side rendering — it returns `false` when `window` is undefined.
 
 ```javascript
-import Vocal, { isSupported } from '@untemps/react-vocal'
+import { Vocal, isSupported } from '@untemps/react-vocal'
 
 const App = () => {
 	return isSupported() ? <Vocal /> : <p>Your browser does not support Web Speech API</p>
@@ -499,7 +517,7 @@ The library has no dedicated injection prop — tests inject a custom vocal inst
 ```typescript
 import { createVocal, type VocalInstance } from '@untemps/vocal'
 import { render } from '@testing-library/react'
-import Vocal from '@untemps/react-vocal'
+import { Vocal } from '@untemps/react-vocal'
 
 vi.mock('@untemps/vocal', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('@untemps/vocal')>()

--- a/dev/src/index.jsx
+++ b/dev/src/index.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 
-import Vocal from '../../src'
+import { Vocal } from '../../src'
 
 const COMMANDS = {
 	rouge: 'red',

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -4,7 +4,7 @@ export interface IconProps {
 	isActive?: boolean
 }
 
-const Icon = ({ color = 'black', activeColor = 'red', isActive = false }: IconProps) => {
+export const Icon = ({ color = 'black', activeColor = 'red', isActive = false }: IconProps) => {
 	return (
 		<svg
 			data-testid="__icon-root__"
@@ -25,5 +25,3 @@ const Icon = ({ color = 'black', activeColor = 'red', isActive = false }: IconPr
 		</svg>
 	)
 }
-
-export default Icon

--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -109,7 +109,7 @@ const tryMatchCommand = (results: Iterable<Iterable<ResultSegmentLike>>, trigger
 	}
 }
 
-const Vocal = ({
+export const Vocal = ({
 	children,
 	commands = null,
 	lang = 'en-US',
@@ -369,5 +369,3 @@ const Vocal = ({
 
 	return _renderChildren()
 }
-
-export default Vocal

--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -11,9 +11,9 @@ import {
 import { isSupported as isSupportedFn } from '@untemps/vocal'
 import { isFunction } from '@untemps/utils/function/isFunction'
 
-import useVocal from '../hooks/useVocal'
+import { useVocal } from '../hooks/useVocal'
 import useTimeout from '../hooks/useTimeout'
-import useCommands, { type CommandsMap, type TriggerCommand } from '../hooks/useCommands'
+import { useCommands, type CommandsMap, type TriggerCommand } from '../hooks/useCommands'
 
 import Icon from './Icon'
 

--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -12,10 +12,10 @@ import { isSupported as isSupportedFn } from '@untemps/vocal'
 import { isFunction } from '@untemps/utils/function/isFunction'
 
 import { useVocal } from '../hooks/useVocal'
-import useTimeout from '../hooks/useTimeout'
+import { useTimeout } from '../hooks/useTimeout'
 import { useCommands, type CommandsMap, type TriggerCommand } from '../hooks/useCommands'
 
-import Icon from './Icon'
+import { Icon } from './Icon'
 
 export type OnResultCallback = (bestAlternative: string, event: SpeechRecognitionEvent | Event) => void
 

--- a/src/components/__tests__/Icon.test.tsx
+++ b/src/components/__tests__/Icon.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 
-import Icon from '../Icon'
+import { Icon } from '../Icon'
 
 const defaultProps = {}
 const getInstance = (props = {}) => <Icon {...defaultProps} {...props} />

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -897,7 +897,7 @@ describe('Vocal', () => {
 		// Mock useVocal so subscribe() throws synchronously inside startRecognition.
 		// Scoped via vi.doMock + dynamic import so the rest of the suite uses the real hook.
 		vi.doMock('../../hooks/useVocal', () => ({
-			default: () => [
+			useVocal: () => [
 				null,
 				{
 					subscribe: () => {

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -2,7 +2,7 @@ import { waitFor } from '@testing-library/dom'
 import { act, fireEvent, render } from '@testing-library/react'
 import { createVocal, isSupported, type VocalInstance } from '@untemps/vocal'
 
-import Vocal, { type VocalProps } from '../Vocal'
+import { Vocal, type VocalProps } from '../Vocal'
 import { createMockVocal } from './createMockVocal'
 
 vi.mock('@untemps/vocal', async (importOriginal) => {
@@ -907,7 +907,7 @@ describe('Vocal', () => {
 			],
 		}))
 		vi.resetModules()
-		const { default: VocalWithMockedUseVocal } = await import('../Vocal')
+		const { Vocal: VocalWithMockedUseVocal } = await import('../Vocal')
 		const onError = vi.fn()
 		const { getByTestId } = render(<VocalWithMockedUseVocal onError={onError} />)
 		await act(async () => {

--- a/src/hooks/__tests__/useCommands.test.ts
+++ b/src/hooks/__tests__/useCommands.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react'
 
-import useCommands from '../useCommands'
+import { useCommands } from '../useCommands'
 
 // Static import anchors fuse.js in the module graph so vi.mock intercepts the
 // dynamic import('fuse.js') inside the hook. Without it the dynamic import resolves
@@ -103,7 +103,7 @@ describe('useCommands', () => {
 		vi.doMock('fuse.js', () => {
 			throw new Error('fuse.js not installed')
 		})
-		const { default: useCommandsWithoutFuse } = await import('../useCommands')
+		const { useCommands: useCommandsWithoutFuse } = await import('../useCommands')
 		const commands = { 'change color': () => 'matched' }
 		const {
 			result: { current: triggerCommand },
@@ -121,7 +121,7 @@ describe('useCommands', () => {
 		vi.doMock('fuse.js', () => {
 			throw new Error('fuse.js not installed')
 		})
-		const { default: useCommandsFresh } = await import('../useCommands')
+		const { useCommands: useCommandsFresh } = await import('../useCommands')
 		const commands = { 'change color': () => 'matched' }
 		const { unmount } = renderHook(() => useCommandsFresh(commands))
 		unmount()

--- a/src/hooks/__tests__/useTimeout.test.ts
+++ b/src/hooks/__tests__/useTimeout.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react'
 
-import useTimeout from '../useTimeout'
+import { useTimeout } from '../useTimeout'
 
 const wait = (delay: number): Promise<void> => {
 	return new Promise((resolve) => {

--- a/src/hooks/__tests__/useVocal.test.ts
+++ b/src/hooks/__tests__/useVocal.test.ts
@@ -1,7 +1,7 @@
 import { act, renderHook } from '@testing-library/react'
 import { createVocal, isSupported } from '@untemps/vocal'
 
-import useVocal from '../useVocal'
+import { useVocal } from '../useVocal'
 
 vi.mock('@untemps/vocal')
 

--- a/src/hooks/useCommands.ts
+++ b/src/hooks/useCommands.ts
@@ -7,7 +7,7 @@ export type CommandsMap = Record<string, CommandCallback>
 
 export type TriggerCommand = (rawInput: string) => unknown
 
-const useCommands = (commands?: CommandsMap | null, precision: number = 0.4): TriggerCommand => {
+export const useCommands = (commands?: CommandsMap | null, precision: number = 0.4): TriggerCommand => {
 	const normalized = useMemo<CommandsMap>(
 		() =>
 			commands
@@ -90,5 +90,3 @@ const useCommands = (commands?: CommandsMap | null, precision: number = 0.4): Tr
 
 	return triggerCommand
 }
-
-export default useCommands

--- a/src/hooks/useTimeout.ts
+++ b/src/hooks/useTimeout.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react'
 
-const useTimeout = (handler: () => void, timeout: number = 0): [start: () => void, stop: () => void] => {
+export const useTimeout = (handler: () => void, timeout: number = 0): [start: () => void, stop: () => void] => {
 	const ref = useRef<ReturnType<typeof setTimeout> | number>(-1)
 
 	const stop = useCallback(() => {
@@ -17,5 +17,3 @@ const useTimeout = (handler: () => void, timeout: number = 0): [start: () => voi
 
 	return [start, stop]
 }
-
-export default useTimeout

--- a/src/hooks/useVocal.ts
+++ b/src/hooks/useVocal.ts
@@ -26,7 +26,7 @@ export interface UseVocalActions {
 
 export type UseVocalReturn = [RefObject<VocalInstance | null>, UseVocalActions]
 
-const useVocal = (
+export const useVocal = (
 	lang: string = 'en-US',
 	grammars: SpeechGrammarList | null = null,
 	maxAlternatives: number = 1,
@@ -124,5 +124,3 @@ const useVocal = (
 
 	return [ref, { start, stop, abort, subscribe, unsubscribe, clean, isRecording }]
 }
-
-export default useVocal

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,6 @@ export {
 	type VocalError,
 	type VocalErrorType,
 } from './components/Vocal'
-export { default as useVocal } from './hooks/useVocal'
-export type { UseVocalActions, UseVocalReturn } from './hooks/useVocal'
-export { default as useCommands } from './hooks/useCommands'
-export type { CommandCallback, CommandsMap, TriggerCommand } from './hooks/useCommands'
+export { useVocal, type UseVocalActions, type UseVocalReturn } from './hooks/useVocal'
+export { useCommands, type CommandCallback, type CommandsMap, type TriggerCommand } from './hooks/useCommands'
 export { isSupported } from '@untemps/vocal'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,5 @@
-import Vocal from './components/Vocal'
-
-export { default as useVocal } from './hooks/useVocal'
-export type { UseVocalActions, UseVocalReturn } from './hooks/useVocal'
-export { default as useCommands } from './hooks/useCommands'
-export type { CommandCallback, CommandsMap, TriggerCommand } from './hooks/useCommands'
 export {
+	Vocal,
 	classifyError,
 	type VocalProps,
 	type OnResultCallback,
@@ -12,6 +7,8 @@ export {
 	type VocalError,
 	type VocalErrorType,
 } from './components/Vocal'
+export { default as useVocal } from './hooks/useVocal'
+export type { UseVocalActions, UseVocalReturn } from './hooks/useVocal'
+export { default as useCommands } from './hooks/useCommands'
+export type { CommandCallback, CommandsMap, TriggerCommand } from './hooks/useCommands'
 export { isSupported } from '@untemps/vocal'
-
-export default Vocal


### PR DESCRIPTION
## Summary

The barrel `src/index.ts` previously exposed both a default export (`Vocal`) and named exports for the rest of the public surface. Rollup emitted a `MIXED_EXPORTS` warning on every `yarn build`, and pure CJS consumers (`const Vocal = require('@untemps/react-vocal')`) had to access the component via `.default`. This PR drops the default export and consolidates the public surface around named exports, removing the warning at its source and aligning the ESM/CJS shapes.

## Changes

- `src/components/Vocal.tsx` — `const Vocal = …; export default Vocal` → `export const Vocal = …`.
- `src/index.ts` — consolidated re-export block, no `export default`.
- `src/components/__tests__/Vocal.test.tsx` — updated to the named import (including the `vi.doMock` dynamic import branch).
- `dev/src/index.jsx` — demo aligned with the new shape.
- `README.md` — all 5 examples updated to `import { Vocal } …` and a new **Migration from 1.x** section documents the ESM + CJS migration paths.

## Verification

- [x] `yarn test:ci` — 142/142 passing
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn build` — **no `MIXED_EXPORTS` warning** (CJS bundle now contains only named exports)
- [x] Manual: `cd dev && yarn dev` boots cleanly with the named import

## ⚠️ Breaking changes

- **`Vocal`** is no longer the default export of `@untemps/react-vocal`. The default-import form is gone for both ESM and CJS.

  Migration:

  ```diff
  - import Vocal from '@untemps/react-vocal'
  + import { Vocal } from '@untemps/react-vocal'
  ```

  ```diff
  - const { default: Vocal } = require('@untemps/react-vocal')
  + const { Vocal } = require('@untemps/react-vocal')
  ```

  TS/ESM consumers using `esModuleInterop` with the old default import will see a TypeScript error pointing them to the named form. CJS consumers using `.default` will get `undefined` at runtime — they must update the destructuring.

Closes #166