### PR TITLE
chore(build): Externalize @untemps/vocal to avoid duplicated runtime

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
 			fileName: bundleFileName,
 		},
 		rollupOptions: {
-			external: ['react', 'react-dom', 'fuse.js'],
+			external: ['react', 'react-dom', 'fuse.js', '@untemps/vocal'],
 		},
 		sourcemap: true,
 	},


### PR DESCRIPTION
## Summary

`@untemps/vocal` was declared as a runtime `dependency` in `package.json` but was also inlined into `dist/index.{cjs,es.js}` because it was missing from `rollupOptions.external`. Consumers received two copies — one bundled, one in `node_modules` — and a consumer mocking `@untemps/vocal` would only intercept the second one.

This PR adds `@untemps/vocal` to the external list. The dependency stays declared in `dependencies`, so npm/yarn/pnpm continue to install it automatically.

## Changes

- `vite.config.ts` — add `'@untemps/vocal'` to `rollupOptions.external`.

## Effects

- Bundle size shrinks meaningfully:
  - ESM: 20.82 → 15.75 kB (-24 %) / gzipped 7.47 → 5.83 kB (-22 %)
  - CJS: 16.36 → 12.46 kB (-24 %) / gzipped 6.53 → 5.05 kB (-23 %)
- Each bundle now contains exactly one `@untemps/vocal` reference (the import) instead of inlining the whole module.
- `dist/index.d.ts` is unchanged — it already imported types from `@untemps/vocal`.
- Consumer code that does `vi.mock('@untemps/vocal', …)` now intercepts the actual runtime used by `react-vocal`, instead of only the duplicated copy.

## Test plan

- [x] `yarn test:ci` — 142/142 passing
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn build` — bundles shrink, exactly one `@untemps/vocal` reference per output
- [x] `grep "@untemps/vocal" dist/index.{cjs,es.js}` — 1 hit each (the externalized import)

Closes #167