### PR TITLE
fix(vocal): Keep continuous session alive on nomatch

### DIFF
--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -251,7 +251,9 @@ export const Vocal = ({
 	const _onNoMatch = useCallback(
 		(e: Event) => {
 			stopTimer()
-			stopRecognition()
+			// In continuous mode an unrecognized segment must not end the session — the
+			// contract is "keep listening across segments". Mirrors the gate in _onResult.
+			if (!continuousRef.current) stopRecognition()
 			propsRef.current.onNoMatch?.(e)
 		},
 		[stopTimer, stopRecognition]

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -734,6 +734,28 @@ describe('Vocal', () => {
 			expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-pressed', 'true')
 		})
 
+		it('keeps session active on nomatch instead of stopping recognition', async () => {
+			const onEnd = vi.fn()
+			const onNoMatch = vi.fn()
+			const recognition = createMockVocal({ continuous: true })
+			const { getByTestId } = render(
+				getInstance({ __rsInstance: recognition, onEnd, onNoMatch, continuous: true })
+			)
+
+			await act(async () => {
+				fireEvent.click(getByTestId('__vocal-root__'))
+			})
+
+			await act(async () => {
+				// say(null) dispatches speechstart → speechend → nomatch
+				recognition.say(null)
+			})
+
+			expect(onNoMatch).toHaveBeenCalledTimes(1)
+			expect(onEnd).not.toHaveBeenCalled()
+			expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-pressed', 'true')
+		})
+
 		it('fires onResult once at session end with full accumulated transcript', async () => {
 			const onResult = vi.fn()
 			const onEnd = vi.fn()


### PR DESCRIPTION
## Summary

`_onNoMatch` (`Vocal.tsx:251`) called `stopRecognition()` unconditionally, terminating the session on the first unrecognized segment even when `continuous=true`. This contradicts the documented contract for continuous mode ("keep listening across segments") and is inconsistent with `_onResult`, which already gates its `stopRecognition()` call on `!continuousRef.current`.

## Changes

- `src/components/Vocal.tsx` — gate `stopRecognition()` in `_onNoMatch` on `!continuousRef.current`. `stopTimer()` stays unconditional so the regular timeout is cleared and can be re-armed on the next `speechend`.
- `src/components/__tests__/Vocal.test.tsx` — add a regression test under `Continuous sessions` that fires `recognition.say(null)` (which dispatches `speechstart` → `speechend` → `nomatch`) and asserts:
  - `onNoMatch` was called once.
  - `onEnd` was **not** called.
  - `aria-pressed` stays `"true"`.

## Test plan

- [x] `yarn test:ci` — 143/143 passing (+1 new test)
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn build`

## Behavior

- **Continuous mode**: `nomatch` no longer terminates the session — consumers receive their `onNoMatch` callback and recognition keeps running.
- **Non-continuous mode**: unchanged. `_onNoMatch` still calls `stopRecognition()`.

Closes #168