### PR TITLE
fix(hooks): Memoize useCommands triggerCommand to stabilize hook identity

### DIFF
--- a/src/hooks/__tests__/useCommands.test.ts
+++ b/src/hooks/__tests__/useCommands.test.ts
@@ -18,6 +18,27 @@ describe('useCommands', () => {
 		expect(triggerCommand).toBeDefined()
 	})
 
+	it('returns a stable triggerCommand across renders when commands prop is referentially equal', () => {
+		const commands = { foo: () => 'bar' }
+		const { result, rerender } = renderHook(({ c }: { c: typeof commands }) => useCommands(c), {
+			initialProps: { c: commands },
+		})
+		const first = result.current
+		rerender({ c: commands })
+		expect(result.current).toBe(first)
+	})
+
+	it('returns a new triggerCommand when the commands prop identity changes', () => {
+		const a = { foo: () => 'bar' }
+		const b = { foo: () => 'bar' }
+		const { result, rerender } = renderHook(({ c }: { c: typeof a }) => useCommands(c), {
+			initialProps: { c: a },
+		})
+		const first = result.current
+		rerender({ c: b })
+		expect(result.current).not.toBe(first)
+	})
+
 	it('triggers callback mapped to the exact input', () => {
 		const commands = {
 			foo: () => 'bar',

--- a/src/hooks/useCommands.ts
+++ b/src/hooks/useCommands.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import type Fuse from 'fuse.js'
 
 export type CommandCallback = (rawInput: string, commandKey: string) => unknown
@@ -57,36 +57,39 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 		}
 	}, [hasPhraseKeys, keys])
 
-	const triggerCommand: TriggerCommand = (rawInput) => {
-		if (!keys.length) return null
+	const triggerCommand = useCallback<TriggerCommand>(
+		(rawInput) => {
+			if (!keys.length) return null
 
-		if (!hasPhraseKeys) {
-			const words = rawInput.trim().split(/\s+/)
-			const targets = words.length > 1 ? words : [rawInput.trim()]
-			for (const w of targets) {
-				const commandKey = w.toLowerCase()
-				if (commandKey in normalized) return normalized[commandKey]?.(w, commandKey)
+			if (!hasPhraseKeys) {
+				const words = rawInput.trim().split(/\s+/)
+				const targets = words.length > 1 ? words : [rawInput.trim()]
+				for (const w of targets) {
+					const commandKey = w.toLowerCase()
+					if (commandKey in normalized) return normalized[commandKey]?.(w, commandKey)
+				}
+				return null
+			}
+
+			const fuse = fuseRef.current
+			if (fuse) {
+				const result = fuse.search(rawInput).filter((r) => (r.score ?? 1) < precision)
+				if (result?.length) {
+					const commandKey = (result[0].item as string).toLowerCase()
+					return normalized[commandKey]?.(rawInput, commandKey)
+				}
+			} else {
+				// `k.includes(lInput)` can produce false positives when input is short
+				// (e.g. "rouge" matches "change en rouge"). Accepted tradeoff: this branch
+				// only runs when fuse.js is absent, so degraded precision is expected.
+				const lInput = rawInput.toLowerCase()
+				const commandKey = keys.find((k) => lInput.includes(k) || k.includes(lInput))
+				if (commandKey) return normalized[commandKey]?.(rawInput, commandKey)
 			}
 			return null
-		}
-
-		const fuse = fuseRef.current
-		if (fuse) {
-			const result = fuse.search(rawInput).filter((r) => (r.score ?? 1) < precision)
-			if (result?.length) {
-				const commandKey = (result[0].item as string).toLowerCase()
-				return normalized[commandKey]?.(rawInput, commandKey)
-			}
-		} else {
-			// `k.includes(lInput)` can produce false positives when input is short
-			// (e.g. "rouge" matches "change en rouge"). Accepted tradeoff: this branch
-			// only runs when fuse.js is absent, so degraded precision is expected.
-			const lInput = rawInput.toLowerCase()
-			const commandKey = keys.find((k) => lInput.includes(k) || k.includes(lInput))
-			if (commandKey) return normalized[commandKey]?.(rawInput, commandKey)
-		}
-		return null
-	}
+		},
+		[keys, normalized, hasPhraseKeys, precision]
+	)
 
 	return triggerCommand
 }


### PR DESCRIPTION
## Summary

`useCommands` rebuilt its `triggerCommand` closure on every render. Now that the hook is part of the public API (#158), any consumer placing `triggerCommand` in a `useEffect`/`useCallback` dependency array would hit infinite re-runs. Wrap the closure in `useCallback` with its real dependencies so the returned function is referentially stable across renders.

Internal `Vocal` usage was already shielded — it reads the trigger via `triggerCommandRef`, which captures whichever closure is current at call time. The fix only changes the contract on the public surface.

## Changes

- `src/hooks/useCommands.ts` — wrap `triggerCommand` in `useCallback<TriggerCommand>(…, [keys, normalized, hasPhraseKeys, precision])`. `fuseRef` stays stable by construction and is not listed.
- `src/hooks/__tests__/useCommands.test.ts` — add two tests:
  - **Stability** : same `commands` reference across `rerender()` → `triggerCommand` is referentially equal.
  - **Identity change** : a new `commands` object (even with identical content) → new `triggerCommand`.

## Test plan

- [x] `yarn test:ci` — 145/145 passing (+2 new tests)
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn build`

## Behavior

The contract becomes **stronger**, not weaker:
- Existing consumers that didn't rely on the identity (e.g. calling `triggerCommand` inline) — unaffected.
- Existing consumers that hit infinite re-runs — fixed.

No breaking change.

Closes #169