### PR TITLE
docs: Realign useVocal start() return-value description with wrapped promise contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ const [ref, { start, stop, abort, subscribe, unsubscribe, clean, isRecording }]
 | Args        | Type | Description                                          |
 | ----------- | ---- | ---------------------------------------------------- |
 | ref         | Ref  | React ref to the underlying `@untemps/vocal` instance |
-| start       | func | Function to start the recognition. Accepts an optional `{ signal }` argument — an `AbortSignal` propagated to the underlying `start()` call. Returns the underlying `vocal.start()` promise (resolves once the session starts, rejects on microphone/permission errors). |
+| start       | func | Function to start the recognition. Accepts an optional `{ signal }` argument — an `AbortSignal` propagated to the underlying `start()` call. Returns a `Promise<void>` that resolves once the session starts and rejects with the original error on microphone/permission failures. |
 | stop        | func | Function to stop the recognition                     |
 | abort       | func | Function to abort the recognition                    |
 | subscribe   | func | Function to subscribe to recognition events          |


### PR DESCRIPTION
## Summary

`README.md:361` claimed `useVocal().start()` "Returns the underlying `vocal.start()` promise". Since #163, the call is wrapped in an `async` function so the returned promise is no longer the same reference — only the behavioral contract is preserved. Reword the entry to describe the contract instead of claiming reference identity.

## Changes

- `README.md` — replace the misleading sentence in the `useVocal` return-value table with: *"Returns a `Promise<void>` that resolves once the session starts and rejects with the original error on microphone/permission failures."*

The *Cancelling a start in flight / Behavior note* paragraph (README:383) already documents the upstream `AbortError` swallow workaround, so the wrap is contextually visible elsewhere.

## Test plan

- [x] `yarn lint` — passes (markdown not linted, but consistency check)
- [x] `yarn test:ci` — 145/145 (no behavior change)

Closes #181