### PR TITLE
chore: Tighten fuse.js peer range to >=7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
 		"vitest": "^4.1.5"
 	},
 	"peerDependencies": {
-		"fuse.js": ">=6.0.0",
+		"fuse.js": ">=7.0.0",
 		"react": ">=16.13.1",
 		"react-dom": ">=16.13.1",
 		"typescript": ">=6.0.0"


### PR DESCRIPTION
## Summary

`peerDependencies.fuse.js` advertised `>=6.0.0`, but the integration is only exercised against the devDependency pin (`^7.3.0`). The dynamic import resolution (`module.default ?? module` in `src/hooks/useCommands.ts`) and the TypeScript types are never validated against fuse 6.x, so the wider range was an untested claim. This aligns the declared range with what CI actually verifies.

## Changes

- `package.json` — `peerDependencies.fuse.js`: `">=6.0.0"` → `">=7.0.0"`.

## Test plan

- [x] `yarn test:ci` — 145/145 passing
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn build`

## User note

This is not flagged as a Conventional Commits breaking change: the package is still in the `2.0.0-beta.x` line and the v1 → v2 break is already covered by #175. A consumer who was testing the beta with fuse 6.x installed will need to upgrade fuse to 7.x — which is precisely the intent (fuse 7 has been stable for over two years). fuse.js remains an optional peer dependency; consumers using only single-word commands are unaffected.

Closes #179