### PR TITLE
chore: Augment globalThis.navigator in vitest.setup.ts instead of overwriting it

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -20,8 +20,6 @@ const MediaDevicesMock = vi.fn(function () {
 	}
 })
 
-// Augment jsdom's real navigator rather than replacing it: only permissions and
-// mediaDevices need mocking (vocal's isSupported reads them); userAgent is left untouched.
 Object.defineProperty(globalThis.navigator, 'permissions', {
 	value: new (PermissionsMock as unknown as new () => unknown)(),
 	writable: true,

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -20,11 +20,8 @@ const MediaDevicesMock = vi.fn(function () {
 	}
 })
 
-Object.defineProperty(globalThis, 'navigator', {
-	value: { userAgent: 'node.js' },
-	writable: true,
-	configurable: true,
-})
+// Augment jsdom's real navigator rather than replacing it: only permissions and
+// mediaDevices need mocking (vocal's isSupported reads them); userAgent is left untouched.
 Object.defineProperty(globalThis.navigator, 'permissions', {
 	value: new (PermissionsMock as unknown as new () => unknown)(),
 	writable: true,


### PR DESCRIPTION
## Summary
`vitest.setup.ts` replaced `globalThis.navigator` wholesale with `{ userAgent: 'node.js' }` before attaching the `permissions` and `mediaDevices` mocks, discarding jsdom's real navigator (`userAgent`, `language`, …) for a fragile, fake baseline. This attaches the mocks to the real navigator instead and drops the replacement.

## Changes
- `vitest.setup.ts` — removed the `Object.defineProperty(globalThis, 'navigator', { value: { userAgent: 'node.js' } })` block. The `permissions` and `mediaDevices` mocks now augment jsdom's real navigator.

## Rationale
`@untemps/vocal`'s `isSupported()` reads only `SpeechRecognition`, `navigator.permissions` and `navigator.mediaDevices` (via `@untemps/user-permissions-utils`) — it never reads `userAgent`. jsdom already provides a realistic `userAgent`, so the `'node.js'` override was unused and misleading. Verified `Object.defineProperty` on jsdom's navigator works and preserves its native properties.

## Test plan
- [ ] `yarn test:ci` — 146 tests pass, coverage unchanged
- [ ] `yarn typecheck` — no errors
- [ ] `yarn lint` — clean
- [ ] `yarn build` — ES + CJS bundles built

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)