### PR TITLE
chore: Include dev/ in ESLint to catch demo regressions at lint time

### DIFF
--- a/dev/src/index.jsx
+++ b/dev/src/index.jsx
@@ -29,7 +29,6 @@ const App = () => {
 					},
 				])
 			),
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[]
 	)
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,8 +5,9 @@ import globals from 'globals'
 
 export default tseslint.config(
 	{
-		ignores: ['dist/**', 'coverage/**', 'dev/**', 'node_modules/**'],
+		ignores: ['dist/**', 'coverage/**', 'dev/dist/**', 'node_modules/**'],
 	},
+	{ files: ['**/*.jsx'] },
 	js.configs.recommended,
 	...tseslint.configs.recommended,
 	{

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
 		"test": "vitest",
 		"test:ci": "vitest run --coverage",
 		"typecheck": "tsc --noEmit",
-		"lint": "eslint src vitest.setup.ts",
+		"lint": "eslint src vitest.setup.ts dev/src",
 		"build": "vite build",
 		"prepare": "husky",
 		"prettier": "prettier \"*/**/*.{js,ts,tsx}\" --ignore-path ./.prettierignore --write && git add -u && git status"


### PR DESCRIPTION
## Summary
The demo under `dev/` is executable code that imports the library and serves as a usage reference, but it was excluded from linting, so regressions (stale imports, dead code, unused vars) could ship unchallenged. This brings `dev/src` into the lint scope.

## Changes
- `eslint.config.js` — drop `dev/**` from `ignores` (keep `dev/dist/**` excluded) and register the `.jsx` extension via a `{ files: ['**/*.jsx'] }` block, since the flat config did not pick up `.jsx` files at all.
- `package.json` — `lint` script now runs `eslint src vitest.setup.ts dev/src`.
- `dev/src/index.jsx` — remove the dangling `// eslint-disable-next-line react-hooks/exhaustive-deps` directive. Its plugin (`eslint-plugin-react-hooks`) is not installed yet (tracked in #182), so the directive only produced a "Definition for rule not found" error. The memoized `commands` (`useMemo(..., [])`) is unchanged and correct; #182 will reintroduce the plugin and the directive together.

## Test plan
- [ ] `yarn lint` — now lints `dev/src`, passes clean (verified it catches an injected unused var)
- [ ] `yarn test:ci` — 146 tests pass
- [ ] `yarn typecheck` — no errors
- [ ] `yarn build` — ES + CJS bundles built

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)