### PR TITLE
fix: Snapshot handler identities to prevent listener leaks on prop changes

### DIFF
--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -298,10 +298,9 @@ export const Vocal = ({
 	const startRecognition = useCallback(() => {
 		try {
 			stopSilenceTimer()
-			const handlers = HANDLERS
-			Object.entries(handlers).forEach(([event, fn]) => subscribe(event, fn as (e: Event) => void))
+			Object.entries(HANDLERS).forEach(([event, fn]) => subscribe(event, fn as (e: Event) => void))
 			unsubscribeAllRef.current = () =>
-				Object.entries(handlers).forEach(([event, fn]) => unsubscribe?.(event, fn as (e: Event) => void))
+				Object.entries(HANDLERS).forEach(([event, fn]) => unsubscribe(event, fn as (e: Event) => void))
 			// useVocal's start() rejects on microphone/permission errors — catch
 			// the async rejection so it doesn't surface as an UnhandledPromiseRejection.
 			start({ signal: signal ?? undefined }).catch(_onError)

--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -295,21 +295,20 @@ export const Vocal = ({
 		[_onStart, _onEnd, _onSpeechStart, _onSpeechEnd, _onResult, _onError, _onNoMatch]
 	)
 
-	// Assigned inline (not in useEffect) so it's ready before any event fires
-	unsubscribeAllRef.current = () =>
-		Object.entries(HANDLERS).forEach(([event, fn]) => unsubscribe?.(event, fn as (e: Event) => void))
-
 	const startRecognition = useCallback(() => {
 		try {
 			stopSilenceTimer()
-			Object.entries(HANDLERS).forEach(([event, fn]) => subscribe(event, fn as (e: Event) => void))
+			const handlers = HANDLERS
+			Object.entries(handlers).forEach(([event, fn]) => subscribe(event, fn as (e: Event) => void))
+			unsubscribeAllRef.current = () =>
+				Object.entries(handlers).forEach(([event, fn]) => unsubscribe?.(event, fn as (e: Event) => void))
 			// useVocal's start() rejects on microphone/permission errors — catch
 			// the async rejection so it doesn't surface as an UnhandledPromiseRejection.
 			start({ signal: signal ?? undefined }).catch(_onError)
 		} catch (error) {
 			_onError(error)
 		}
-	}, [HANDLERS, subscribe, start, stopSilenceTimer, _onError, signal])
+	}, [HANDLERS, subscribe, unsubscribe, start, stopSilenceTimer, _onError, signal])
 
 	const _onFocus = useCallback(() => {
 		if (!className && outlineStyle && buttonRef.current) {

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -716,6 +716,106 @@ describe('Vocal', () => {
 		expect(onError).not.toHaveBeenCalled()
 	})
 
+	it('does not leak listeners when timeout changes during an active session', async () => {
+		const onEnd = vi.fn()
+		const onResult = vi.fn()
+		const recognition = createMockVocal()
+		const { getByTestId, rerender } = render(
+			getInstance({ __rsInstance: recognition, onEnd, onResult, timeout: 1000 })
+		)
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+			await waitFor(() => expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-pressed', 'true'))
+		})
+
+		await act(async () => {
+			rerender(getInstance({ __rsInstance: recognition, onEnd, onResult, timeout: 2000 }))
+		})
+
+		await act(async () => {
+			recognition.say('Foo')
+			await waitFor(() => expect(onEnd).toHaveBeenCalledTimes(1))
+		})
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+			await waitFor(() => expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-pressed', 'true'))
+		})
+
+		await act(async () => {
+			recognition.say('Bar')
+			await waitFor(() => expect(onEnd).toHaveBeenCalledTimes(2))
+		})
+
+		expect(onEnd).toHaveBeenCalledTimes(2)
+		expect(onResult).toHaveBeenCalledTimes(2)
+		expect(onResult).toHaveBeenNthCalledWith(1, 'Foo', expect.anything())
+		expect(onResult).toHaveBeenNthCalledWith(2, 'Bar', expect.anything())
+	})
+
+	it('does not leak listeners when silenceTimeout changes during an active continuous session', async () => {
+		const onEnd = vi.fn()
+		const onResult = vi.fn()
+		const recognition = createMockVocal({ continuous: true })
+		const { getByTestId, rerender } = render(
+			getInstance({
+				__rsInstance: recognition,
+				onEnd,
+				onResult,
+				continuous: true,
+				timeout: 10_000,
+				silenceTimeout: 5000,
+			})
+		)
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+			await waitFor(() => expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-pressed', 'true'))
+		})
+
+		await act(async () => {
+			rerender(
+				getInstance({
+					__rsInstance: recognition,
+					onEnd,
+					onResult,
+					continuous: true,
+					timeout: 10_000,
+					silenceTimeout: 7000,
+				})
+			)
+		})
+
+		await act(async () => {
+			recognition.say('Hello')
+		})
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+			await waitFor(() => expect(onEnd).toHaveBeenCalledTimes(1))
+		})
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+			await waitFor(() => expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-pressed', 'true'))
+		})
+
+		await act(async () => {
+			recognition.say('World')
+		})
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+			await waitFor(() => expect(onEnd).toHaveBeenCalledTimes(2))
+		})
+
+		expect(onEnd).toHaveBeenCalledTimes(2)
+		expect(onResult).toHaveBeenCalledTimes(2)
+		expect(onResult).toHaveBeenNthCalledWith(1, 'Hello', expect.anything())
+		expect(onResult).toHaveBeenNthCalledWith(2, 'World', expect.anything())
+	})
+
 	it('calls onEnd via the end event when stop is asynchronous', async () => {
 		const onEnd = vi.fn()
 		const recognition = createMockVocal()


### PR DESCRIPTION
## Summary
Fixes a listener leak in `<Vocal>` when `timeout` or `silenceTimeout` change during an active recognition session. Without this fix, each prop change leaves the previous session's handlers attached to the underlying `VocalInstance`; the next session subscribes a fresh batch on top, so `onEnd`/`onResult`/`onSpeechStart`/etc. fire twice (then three times, then N+1 times after N prop changes).

## Changes
- `src/components/Vocal.tsx` — move the assignment of `unsubscribeAllRef.current` out of the inline render-time path and into `startRecognition`, capturing a local snapshot of `HANDLERS` at the exact moment `subscribe()` is called. The unsubscribe closure now matches the handler identities that were registered for that session, regardless of any subsequent rerender. Added `unsubscribe` to the `useCallback` deps.
- `src/components/__tests__/Vocal.test.tsx` — two regression tests:
  - `does not leak listeners when timeout changes during an active session` — drives session 1 with `timeout: 1000`, rerenders to `timeout: 2000`, ends session 1, starts session 2, ends it; asserts `onEnd`/`onResult` fire exactly twice (once per session).
  - `does not leak listeners when silenceTimeout changes during an active continuous session` — same scenario in continuous mode with a mid-session `silenceTimeout` rerender.

## Test plan
- [x] `yarn test:ci` — 152 tests passing, coverage thresholds met
- [x] `yarn build` — both ESM and CJS bundles built, type declarations generated
- [x] `yarn typecheck` — no errors
- [x] `yarn lint` — no warnings
- [x] `yarn dev` — demo boots cleanly on http://localhost:10001/

Closes #198