### PR TITLE
fix: Preserve consumer onClick on element-as-child

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ If the child element already declares its own `onClick`, it is preserved: your h
 recognition toggle. This lets you attach analytics or any other behavior to the same element without losing the
 toggle.
 
+To cancel the toggle (e.g. require a confirmation, block while the user is unauthenticated), call
+`event.preventDefault()` inside your handler — the recognition will not start or stop for that click.
+
 -   With a function that returns a React element:
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ In this case, an `onClick` handler is automatically attached to the component to
 Only the first direct descendant of Vocal will receive the `onClick` handler. If you want to use a more complex
 hierarchy, use the function syntax below.
 
+If the child element already declares its own `onClick`, it is preserved: your handler runs first, then the
+recognition toggle. This lets you attach analytics or any other behavior to the same element without losing the
+toggle.
+
 -   With a function that returns a React element:
 
 ```javascript

--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -5,6 +5,7 @@ import {
 	useMemo,
 	useRef,
 	type CSSProperties,
+	type MouseEvent as ReactMouseEvent,
 	type ReactElement,
 	type ReactNode,
 } from 'react'
@@ -358,8 +359,13 @@ export const Vocal = ({
 					isListening
 				)
 			} else if (isValidElement(children)) {
-				return cloneElement(children as ReactElement<{ onClick?: () => void }>, {
-					onClick: isListening ? stopRecognition : startRecognition,
+				const typed = children as ReactElement<{ onClick?: (e: ReactMouseEvent) => void }>
+				const childOnClick = typed.props.onClick
+				return cloneElement(typed, {
+					onClick: (e: ReactMouseEvent) => {
+						childOnClick?.(e)
+						;(isListening ? stopRecognition : startRecognition)()
+					},
 				})
 			} else {
 				return _renderDefault()

--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -364,6 +364,7 @@ export const Vocal = ({
 				return cloneElement(typed, {
 					onClick: (e: ReactMouseEvent) => {
 						childOnClick?.(e)
+						if (e.defaultPrevented) return
 						;(isListening ? stopRecognition : startRecognition)()
 					},
 				})

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -100,6 +100,27 @@ describe('Vocal', () => {
 		expect(consumerOnClick).toHaveBeenCalledTimes(2)
 	})
 
+	it('cancels the recognition toggle when the consumer onClick calls preventDefault', async () => {
+		const onStart = vi.fn()
+		const onEnd = vi.fn()
+		const consumerOnClick = vi.fn((e: { preventDefault: () => void }) => e.preventDefault())
+		const recognition = createMockVocal()
+		const { getByTestId } = render(
+			getInstance(
+				{ __rsInstance: recognition, onStart, onEnd },
+				<button data-testid="__vocal-custom-root__" onClick={consumerOnClick} />
+			)
+		)
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-custom-root__'))
+		})
+
+		expect(consumerOnClick).toHaveBeenCalledTimes(1)
+		expect(onStart).not.toHaveBeenCalled()
+		expect(onEnd).not.toHaveBeenCalled()
+	})
+
 	it('renders no children element if SpeechRecognition is not supported', () => {
 		vi.mocked(isSupported).mockReturnValueOnce(false)
 		const { queryByTestId } = render(getInstance(null, <div data-testid="__vocal-custom-root__" />))

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -74,6 +74,32 @@ describe('Vocal', () => {
 		})
 	})
 
+	it('preserves consumer onClick when toggling recognition with a child element', async () => {
+		const onStart = vi.fn()
+		const onEnd = vi.fn()
+		const consumerOnClick = vi.fn()
+		const recognition = createMockVocal()
+		const { getByTestId } = render(
+			getInstance(
+				{ __rsInstance: recognition, onStart, onEnd },
+				<button data-testid="__vocal-custom-root__" onClick={consumerOnClick} />
+			)
+		)
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-custom-root__'))
+			await waitFor(() => expect(onStart).toHaveBeenCalled())
+		})
+		expect(consumerOnClick).toHaveBeenCalledTimes(1)
+		expect(consumerOnClick).toHaveBeenNthCalledWith(1, expect.objectContaining({ type: 'click' }))
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-custom-root__'))
+			await waitFor(() => expect(onEnd).toHaveBeenCalled())
+		})
+		expect(consumerOnClick).toHaveBeenCalledTimes(2)
+	})
+
 	it('renders no children element if SpeechRecognition is not supported', () => {
 		vi.mocked(isSupported).mockReturnValueOnce(false)
 		const { queryByTestId } = render(getInstance(null, <div data-testid="__vocal-custom-root__" />))

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -1,3 +1,4 @@
+import { type MouseEvent as ReactMouseEvent } from 'react'
 import { waitFor } from '@testing-library/dom'
 import { act, fireEvent, render } from '@testing-library/react'
 import { createVocal, isSupported, type VocalInstance } from '@untemps/vocal'
@@ -103,7 +104,7 @@ describe('Vocal', () => {
 	it('cancels the recognition toggle when the consumer onClick calls preventDefault', async () => {
 		const onStart = vi.fn()
 		const onEnd = vi.fn()
-		const consumerOnClick = vi.fn((e: { preventDefault: () => void }) => e.preventDefault())
+		const consumerOnClick = vi.fn((e: ReactMouseEvent) => e.preventDefault())
 		const recognition = createMockVocal()
 		const { getByTestId } = render(
 			getInstance(


### PR DESCRIPTION
## Summary
Fixes a silent bug in `<Vocal>` element-as-child: when a consumer attaches their own `onClick` to a child element (e.g. `<Vocal><button onClick={trackAnalytics}>Mic</button></Vocal>`), it is silently overridden by the recognition toggle inside `cloneElement`. Their handler becomes dead code with no warning.

In addition, the consumer can now call `event.preventDefault()` from their handler to cancel the recognition toggle for that click — useful for confirmation flows, auth gates, or any condition that should suppress the start/stop.

## Changes
- `src/components/Vocal.tsx` — in `_renderChildren`, read the existing `onClick` from `children.props` and pass a composed handler to `cloneElement`. The consumer's handler runs first with the original `MouseEvent`; if `event.defaultPrevented` is true after that call, the toggle is skipped, otherwise `startRecognition` / `stopRecognition` is invoked. Adds a typed `ReactMouseEvent` import.
- `src/components/__tests__/Vocal.test.tsx` — two regression tests:
  - `preserves consumer onClick when toggling recognition with a child element` — asserts the consumer's `onClick` fires on both the start click and the stop click, alongside `onStart` / `onEnd`.
  - `cancels the recognition toggle when the consumer onClick calls preventDefault` — asserts neither `onStart` nor `onEnd` fire when the consumer's handler calls `preventDefault()`.
- `README.md` — documents both the `onClick` preservation and the `preventDefault` escape hatch.

## Test plan
- [x] `yarn test:ci` — 154 tests passing (152 + 2 new), 100% statement/line coverage on `Vocal.tsx`
- [x] `yarn build` — ESM and CJS bundles built, type declarations generated
- [x] `yarn typecheck` — no errors
- [x] `yarn lint` — no warnings
- [x] `yarn dev` — demo boots cleanly on http://localhost:10001/

Closes #199
