### PR TITLE
fix: Coalesce empty-string input to 'unknown' message in classifyError

### DIFF
--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -71,7 +71,7 @@ export const classifyError = (err: unknown): VocalError => {
 	if (err instanceof Error) {
 		return { type: 'unknown', message: err.message || 'unknown', original: err }
 	}
-	return { type: 'unknown', message: typeof err === 'string' ? err : 'unknown', original: err }
+	return { type: 'unknown', message: typeof err === 'string' && err ? err : 'unknown', original: err }
 }
 
 export interface VocalProps {

--- a/src/components/__tests__/classifyError.test.ts
+++ b/src/components/__tests__/classifyError.test.ts
@@ -92,7 +92,7 @@ describe('classifyError', () => {
 			})
 		})
 
-		it.each([null, undefined, 42, true, { foo: 'bar' }])(
+		it.each([null, undefined, 42, true, { foo: 'bar' }, ''])(
 			'classifies non-Error value %p as "unknown" with fallback message',
 			(value) => {
 				expect(classifyError(value)).toEqual({


### PR DESCRIPTION
## Summary
Fixes `classifyError('')` returning `{ type: 'unknown', message: '', original: '' }` instead of coalescing the empty message to `'unknown'`. Every other branch in `classifyError` already coalesces falsy/missing messages — this branch was the odd one out.

## Changes
- `src/components/Vocal.tsx:74` — add the truthy check on the string before using it as the message: `typeof err === 'string' && err ? err : 'unknown'`. Mirrors the `||` coalescing pattern used in the SR-error, DOMException, and generic-Error branches.
- `src/components/__tests__/classifyError.test.ts` — extend the existing `it.each([null, undefined, 42, true, { foo: 'bar' }])` parametrized test with `''`, since the expected result is the same fallback shape.

## Test plan
- [x] `yarn test:ci` — 155 tests passing (154 + 1 new), 100% statement/line coverage on `Vocal.tsx`
- [x] `yarn build` — ESM and CJS bundles built, type declarations generated
- [x] `yarn typecheck` — no errors
- [x] `yarn lint` — no warnings
- [x] `yarn dev` — demo boots cleanly on http://localhost:10001/

Closes #200