### PR TITLE
test: Cover changing timeout/silenceTimeout mid-session in Vocal tests

### DIFF
--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -908,6 +908,8 @@ describe('Vocal', () => {
 				silenceTimeout: 5000,
 			})
 		)
+		// useVocal subscribes a few internal listeners on mount — snapshot the baseline
+		// AFTER render so we only measure what the click adds and the end-of-session removes.
 		const baseline = recognition.handlerCount()
 
 		await act(async () => {

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -864,6 +864,84 @@ describe('Vocal', () => {
 		expect(onResult).toHaveBeenNthCalledWith(2, 'World', expect.anything())
 	})
 
+	it('releases all listeners after a single session when timeout changes mid-session', async () => {
+		const onEnd = vi.fn()
+		const onResult = vi.fn()
+		const recognition = createMockVocal()
+		const { getByTestId, rerender } = render(
+			getInstance({ __rsInstance: recognition, onEnd, onResult, timeout: 1000 })
+		)
+		// useVocal subscribes a few internal listeners on mount — snapshot the baseline
+		// AFTER render so we only measure what the click adds and the end-of-session removes.
+		const baseline = recognition.handlerCount()
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+			await waitFor(() => expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-pressed', 'true'))
+		})
+
+		await act(async () => {
+			rerender(getInstance({ __rsInstance: recognition, onEnd, onResult, timeout: 2000 }))
+		})
+
+		await act(async () => {
+			recognition.say('Foo')
+			await waitFor(() => expect(onEnd).toHaveBeenCalledTimes(1))
+		})
+
+		expect(onEnd).toHaveBeenCalledTimes(1)
+		expect(onResult).toHaveBeenCalledTimes(1)
+		expect(recognition.handlerCount()).toBe(baseline)
+	})
+
+	it('releases all listeners after a single session when silenceTimeout changes mid-session', async () => {
+		const onEnd = vi.fn()
+		const onResult = vi.fn()
+		const recognition = createMockVocal({ continuous: true })
+		const { getByTestId, rerender } = render(
+			getInstance({
+				__rsInstance: recognition,
+				onEnd,
+				onResult,
+				continuous: true,
+				timeout: 10_000,
+				silenceTimeout: 5000,
+			})
+		)
+		const baseline = recognition.handlerCount()
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+			await waitFor(() => expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-pressed', 'true'))
+		})
+
+		await act(async () => {
+			rerender(
+				getInstance({
+					__rsInstance: recognition,
+					onEnd,
+					onResult,
+					continuous: true,
+					timeout: 10_000,
+					silenceTimeout: 7000,
+				})
+			)
+		})
+
+		await act(async () => {
+			recognition.say('Hello')
+		})
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+			await waitFor(() => expect(onEnd).toHaveBeenCalledTimes(1))
+		})
+
+		expect(onEnd).toHaveBeenCalledTimes(1)
+		expect(onResult).toHaveBeenCalledTimes(1)
+		expect(recognition.handlerCount()).toBe(baseline)
+	})
+
 	it('calls onEnd via the end event when stop is asynchronous', async () => {
 		const onEnd = vi.fn()
 		const recognition = createMockVocal()

--- a/src/components/__tests__/createMockVocal.ts
+++ b/src/components/__tests__/createMockVocal.ts
@@ -35,10 +35,11 @@ export interface MockVocalOptions {
 export type MockVocalInput = string | Segment[] | null | undefined
 
 // MockVocalInstance extends VocalInstance with test-only helpers (.say, .error,
-// .end, .fire). Production code consuming a VocalInstance MUST NOT call them —
-// they exist only to drive lifecycle events during tests. Lifecycle methods are
-// typed as MockedFunction so test bodies can call `.mockImplementation()` on
-// them when they need to override behavior.
+// .end, .fire, .handlerCount). Production code consuming a VocalInstance MUST
+// NOT call them — they exist only to drive lifecycle events during tests and
+// inspect the listener map. Lifecycle methods are typed as MockedFunction so
+// test bodies can call `.mockImplementation()` on them when they need to
+// override behavior.
 export interface MockVocalInstance extends Omit<VocalInstance, 'start' | 'stop' | 'abort' | 'on' | 'off' | 'cleanup'> {
 	start: MockedFunction<VocalInstance['start']>
 	stop: MockedFunction<VocalInstance['stop']>
@@ -50,6 +51,7 @@ export interface MockVocalInstance extends Omit<VocalInstance, 'start' | 'stop' 
 	say: (input: MockVocalInput) => void
 	error: (err: unknown) => void
 	end: () => void
+	handlerCount: () => number
 }
 
 // Mock VocalInstance for component tests — implements the contract of
@@ -149,6 +151,9 @@ export const createMockVocal = (options: MockVocalOptions = {}): MockVocalInstan
 		},
 		end() {
 			fire('end', new Event('end'))
+		},
+		handlerCount() {
+			return Object.values(handlers).reduce((sum, arr) => sum + arr.length, 0)
 		},
 	}
 	return instance


### PR DESCRIPTION
## Summary
Adds two single-session regression tests that lock the listener-leak contract directly, complementing the indirect two-session tests already in place. Pairs with the fix from #198 to prevent any future regression from slipping through CI.

## Why a new test if #198 is already covered?
The existing `does not leak listeners when timeout/silenceTimeout changes during an active session` tests prove the absence of leak **indirectly** through a two-session scenario (if unsubscribe failed, callbacks would fire more than expected). The new tests prove it **directly** by snapshotting the listener count on the underlying mock instance before the click and asserting it returns to baseline after the session ends.

## Changes
- `src/components/__tests__/createMockVocal.ts` — add a test-only `handlerCount()` helper to `MockVocalInstance`. Returns the total number of currently registered listeners across all event types (sum of `handlers[*].length`). Documented alongside the existing test-only helpers (`.say`, `.error`, `.end`, `.fire`).
- `src/components/__tests__/Vocal.test.tsx` — two new tests modelled on the `calls the updated onEnd prop after a re-render during an active session` pattern (single session, mid-session rerender, single `recognition.say()`):
  - `releases all listeners after a single session when timeout changes mid-session`
  - `releases all listeners after a single session when silenceTimeout changes mid-session` (continuous mode)

Each asserts:
- `onEnd` called exactly once
- `onResult` called exactly once
- `recognition.handlerCount()` returns to the post-mount baseline after the session ends

The baseline is snapshotted **after** render (not before) because `useVocal` subscribes a few internal listeners on mount (`start`/`end`/`error` for tracking `isRecording`) — those are not the component's responsibility to clean up.

## Test plan
- [x] `yarn test:ci` — 157 tests passing (155 + 2 new), 100% statement/line coverage on `Vocal.tsx`
- [x] `yarn build` — ESM and CJS bundles built, type declarations generated
- [x] `yarn typecheck` — no errors
- [x] `yarn lint` — no warnings
- [x] `yarn dev` — demo boots cleanly on http://localhost:10001/

Closes #201