### PR TITLE
fix(a11y): Propagate aria-pressed and aria-label to cloned-element children

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ toggle.
 To cancel the toggle (e.g. require a confirmation, block while the user is unauthenticated), call
 `event.preventDefault()` inside your handler — the recognition will not start or stop for that click.
 
+For accessibility parity with the default button, `aria-pressed` is also injected on the cloned child to reflect
+the listening state, and `aria-label` falls back to the `ariaLabel` prop of `<Vocal>` when the child does not
+declare one of its own.
+
 -   With a function that returns a React element:
 
 ```javascript

--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -359,14 +359,21 @@ export const Vocal = ({
 					isListening
 				)
 			} else if (isValidElement(children)) {
-				const typed = children as ReactElement<{ onClick?: (e: ReactMouseEvent) => void }>
+				const typed = children as ReactElement<{
+					onClick?: (e: ReactMouseEvent) => void
+					'aria-pressed'?: boolean
+					'aria-label'?: string
+				}>
 				const childOnClick = typed.props.onClick
+				const childAriaLabel = typed.props['aria-label']
 				return cloneElement(typed, {
 					onClick: (e: ReactMouseEvent) => {
 						childOnClick?.(e)
 						if (e.defaultPrevented) return
 						;(isListening ? stopRecognition : startRecognition)()
 					},
+					'aria-pressed': isListening,
+					'aria-label': childAriaLabel ?? ariaLabel,
 				})
 			} else {
 				return _renderDefault()

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -122,6 +122,51 @@ describe('Vocal', () => {
 		expect(onEnd).not.toHaveBeenCalled()
 	})
 
+	it('propagates aria-pressed=false on the cloned child while idle', () => {
+		const { getByTestId } = render(getInstance(null, <button data-testid="__vocal-custom-root__" />))
+		expect(getByTestId('__vocal-custom-root__')).toHaveAttribute('aria-pressed', 'false')
+	})
+
+	it('flips aria-pressed on the cloned child between idle, listening and end of session', async () => {
+		const onStart = vi.fn()
+		const onEnd = vi.fn()
+		const recognition = createMockVocal()
+		const { getByTestId } = render(
+			getInstance({ __rsInstance: recognition, onStart, onEnd }, <button data-testid="__vocal-custom-root__" />)
+		)
+
+		expect(getByTestId('__vocal-custom-root__')).toHaveAttribute('aria-pressed', 'false')
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-custom-root__'))
+			await waitFor(() => expect(onStart).toHaveBeenCalled())
+		})
+		expect(getByTestId('__vocal-custom-root__')).toHaveAttribute('aria-pressed', 'true')
+
+		await act(async () => {
+			recognition.say('Foo')
+			await waitFor(() => expect(onEnd).toHaveBeenCalled())
+		})
+		expect(getByTestId('__vocal-custom-root__')).toHaveAttribute('aria-pressed', 'false')
+	})
+
+	it('falls back to the ariaLabel prop on the cloned child when the child has no aria-label', () => {
+		const { getByTestId } = render(
+			getInstance({ ariaLabel: 'start mic' }, <button data-testid="__vocal-custom-root__" />)
+		)
+		expect(getByTestId('__vocal-custom-root__')).toHaveAttribute('aria-label', 'start mic')
+	})
+
+	it("preserves the child's own aria-label over the ariaLabel prop on the cloned child", () => {
+		const { getByTestId } = render(
+			getInstance(
+				{ ariaLabel: 'start mic' },
+				<button data-testid="__vocal-custom-root__" aria-label="custom label" />
+			)
+		)
+		expect(getByTestId('__vocal-custom-root__')).toHaveAttribute('aria-label', 'custom label')
+	})
+
 	it('renders no children element if SpeechRecognition is not supported', () => {
 		vi.mocked(isSupported).mockReturnValueOnce(false)
 		const { queryByTestId } = render(getInstance(null, <div data-testid="__vocal-custom-root__" />))


### PR DESCRIPTION
## Summary
Brings the cloned-element pattern (`<Vocal><button>Mic</button></Vocal>`) to a11y parity with the default-rendered button. Screen readers can now announce the listening state, and the `ariaLabel` prop of `<Vocal>` is honored as a fallback label when the child does not provide its own.

## Changes
- `src/components/Vocal.tsx` — in `_renderChildren`, widen the typed child to include `'aria-pressed'?` and `'aria-label'?`, then inject `aria-pressed={isListening}` and `aria-label={childAriaLabel ?? ariaLabel}` alongside the composed `onClick`. The child's own `aria-label` always wins over the component's `ariaLabel` prop, matching the pattern used for `onClick` composition.
- `src/components/__tests__/Vocal.test.tsx` — four new regression tests:
  - `propagates aria-pressed=false on the cloned child while idle`
  - `flips aria-pressed on the cloned child between idle, listening and end of session`
  - `falls back to the ariaLabel prop on the cloned child when the child has no aria-label`
  - `preserves the child's own aria-label over the ariaLabel prop on the cloned child`
- `README.md` — one paragraph in the "Custom component / With a simple React element" section documenting the injected ARIA attributes and the precedence rule.

## ⚠️ Behavior change worth noting
A consumer whose cloned child relies on the *absence* of `aria-pressed` (e.g. a CSS selector `:not([aria-pressed])`, a snapshot test, or assistive technology that does not expect a toggle role) will see `aria-pressed="false"` after this change. No migration is required for typical usage — this is the a11y-correct behavior — but the diff is observable in tests/snapshots.

## Test plan
- [x] `yarn test:ci` — 161 tests passing (157 + 4 new), 100% statement/line coverage on `Vocal.tsx`
- [x] `yarn build` — ESM and CJS bundles built, type declarations generated
- [x] `yarn typecheck` — no errors
- [x] `yarn lint` — no warnings
- [x] `yarn dev` — demo boots cleanly on http://localhost:10001/

Closes #202