### PR TITLE
docs: Fix typos in README 'Special cases' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ recognition before the timeout elapses.
 
 ### Special cases
 
-Some browsers supports the `SpeechRecognition` API but not all the related APIs.  
-For example, browsers on iOS 14.5, the `SpeechGrammar` and `SpeechGrammarList` and `Permissions` APIs are not supported.
+Some browsers support the `SpeechRecognition` API but not all the related APIs.  
+For example, on iOS 14.5, browsers do not support the `SpeechGrammar`, `SpeechGrammarList`, and `Permissions` APIs.
 
 Although the lack of `SpeechGrammar` and `SpeechGrammarList` is handled by the underlying `@untemps/vocal` library, you need to deal with `Permissions` by yourself.
 


### PR DESCRIPTION
## Summary
Two minor English fixes in the README `Special cases` subsection: a subject-verb disagreement and a sentence that read as a comma splice.

## Changes
- `README.md:35` — `Some browsers supports` → `Some browsers support`.
- `README.md:36` — `For example, browsers on iOS 14.5, the SpeechGrammar and SpeechGrammarList and Permissions APIs are not supported.` → `For example, on iOS 14.5, browsers do not support the SpeechGrammar, SpeechGrammarList, and Permissions APIs.`

Wording matches the suggestion in the issue.

## Test plan
- [x] `git diff` — only the two flagged lines changed
- [x] No code paths or examples affected

Closes #204