### PR TITLE
fix: correct typos in README 'Special cases' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ timeout elapses.
 
 ### Special cases
 
-Some browsers supports the `SpeechRecognition` API but not all the related APIs.  
-For example, browsers on iOS 14.5, the `SpeechGrammar` and `SpeechGrammarList` and `Permissions` APIs are not supported.
+Some browsers support the `SpeechRecognition` API but not all the related APIs.  
+For example, on iOS 14.5, browsers do not support the `SpeechGrammar`, `SpeechGrammarList`, and `Permissions` APIs.
 
 Although the lack of `SpeechGrammar` and `SpeechGrammarList` is handled by the underlaying `@untemps/vocal` library, you need to deal with `Permissions` by yourself.
 


### PR DESCRIPTION
Fixes two minor English issues in the README 'Special cases' subsection as described in #204: corrects subject-verb disagreement ('supports' → 'support') and restructures the iOS 14.5 sentence to remove the comma splice.

---

_This contribution was AI-assisted (Claude). It's a small targeted fix — happy to revise, or just close if it's not a direction you want. No offense taken._