### PR TITLE
fix(vocal): Invoke onResult before stopRecognition to keep onResult/onEnd ordering

### DIFF
--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -235,9 +235,9 @@ export const Vocal = ({
 						? Array.from((event as SpeechRecognitionEvent).results, (segment) => Array.from(segment))
 						: []
 				tryMatchCommand(results, triggerCommandRef.current)
-				stopRecognition()
 			}
 			propsRef.current.onResult?.(bestAlternative, event)
+			if (!continuousRef.current) stopRecognition()
 		},
 		[stopTimer, stopRecognition]
 	)

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -381,6 +381,56 @@ describe('Vocal', () => {
 		})
 	})
 
+	it('fires onResult before onEnd in single-shot mode', async () => {
+		const calls: string[] = []
+		const onResult = vi.fn(() => {
+			calls.push('result')
+		})
+		const onEnd = vi.fn(() => {
+			calls.push('end')
+		})
+		const recognition = createMockVocal()
+		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onResult, onEnd }))
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+		})
+
+		await act(async () => {
+			recognition.say('Foo')
+			await waitFor(() => expect(onEnd).toHaveBeenCalled())
+		})
+
+		expect(calls).toEqual(['result', 'end'])
+	})
+
+	it('fires onResult before onEnd in continuous mode', async () => {
+		const calls: string[] = []
+		const onResult = vi.fn(() => {
+			calls.push('result')
+		})
+		const onEnd = vi.fn(() => {
+			calls.push('end')
+		})
+		const recognition = createMockVocal({ continuous: true })
+		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onResult, onEnd, continuous: true }))
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+		})
+
+		await act(async () => {
+			recognition.say('Hello')
+		})
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+			await waitFor(() => expect(onEnd).toHaveBeenCalled())
+		})
+
+		expect(calls).toEqual(['result', 'end'])
+	})
+
 	it('calls the updated onEnd prop after a re-render during an active session', async () => {
 		const onEndV1 = vi.fn()
 		const onEndV2 = vi.fn()


### PR DESCRIPTION
## Summary
`_onResult` previously called `stopRecognition()` before invoking the consumer's `onResult` callback. If the underlying `stop()` dispatched the `end` event synchronously, the consumer observed `onEnd` *before* `onResult` — the reverse of the spec-implied order. Real browsers fire `end` asynchronously, so this worked in practice, but the order was fragile. The fix reorders `_onResult` so the consumer's `onResult` is invoked first, then `stopRecognition()` runs. The observable order is now always `result` → `end`, regardless of whether `stop()` dispatches `end` synchronously or asynchronously.

## Changes
- `src/components/Vocal.tsx`: In `_onResult`, call `propsRef.current.onResult` before `stopRecognition()`. The continuous-mode branch already deferred session termination to a later click / silence timer, so its ordering is unchanged; the single-shot branch is the one that needed the swap.
- `src/components/__tests__/Vocal.test.tsx`: Two regression tests verifying the call order via a shared `calls` array — one for single-shot mode, one for continuous mode.

## Test plan
- [x] `yarn test:ci` — 163/163 passing (2 new regression tests), coverage thresholds met
- [x] `yarn lint` — clean
- [x] `yarn typecheck` — clean
- [x] `yarn build` — ES + CJS bundles produced
- [x] `yarn dev` — demo starts and renders correctly

Closes #215