### PR TITLE
fix(useVocal): Roll back isRecording whenever the start event does not fire

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ const [, { start }] = useVocal('en-US')
 start({ signal: controller.signal })
 ```
 
-**Behavior note** — the underlying `@untemps/vocal` library currently swallows the `AbortError` internally: the promise returned by `start()` resolves silently rather than rejecting (see [untemps/vocal#129](https://github.com/untemps/vocal/issues/129)). `react-vocal` compensates by detecting `signal.aborted` after resolution and rolling `isRecording` back to `false`, so consumers of `<Vocal>` or `useVocal` do not need any extra handling. If you bypass the hook and access the underlying `VocalInstance` via the ref returned by `useVocal`, you must check `signal.aborted` yourself after `start()` resolves.
+**Behavior note** — the underlying `@untemps/vocal` library currently swallows the `AbortError` internally: the promise returned by `start()` resolves silently rather than rejecting (see [untemps/vocal#129](https://github.com/untemps/vocal/issues/129)). `react-vocal` compensates by tracking whether the `start` event actually fired during the call and rolling `isRecording` back to `false` whenever it did not — regardless of whether a signal was provided — so consumers of `<Vocal>` or `useVocal` do not need any extra handling. If you bypass the hook and access the underlying `VocalInstance` via the ref returned by `useVocal`, you must observe the `start` event yourself to know when recognition truly began.
 
 ### `useCommands` hook
 

--- a/src/hooks/__tests__/useVocal.test.ts
+++ b/src/hooks/__tests__/useVocal.test.ts
@@ -206,6 +206,17 @@ describe('useVocal', () => {
 			expect(result.current[1].isRecording).toBe(false)
 		})
 
+		it('flips isRecording back to false when start() silently resolves without firing start (no signal)', async () => {
+			// Even without a signal, an absent 'start' event means the session did not begin —
+			// the optimistic flag must be rolled back so the UI does not stay stuck on listening.
+			mockStart.mockReturnValue(Promise.resolve())
+			const { result } = renderHook(() => useVocal())
+			await act(async () => {
+				await result.current[1].start()
+			})
+			expect(result.current[1].isRecording).toBe(false)
+		})
+
 		it('flips isRecording back to false when vocal.start() throws synchronously', async () => {
 			// vocal.start() throwing synchronously is caught by the async wrapper
 			// and surfaces as a rejected promise — the rollback still applies.
@@ -220,9 +231,14 @@ describe('useVocal', () => {
 		})
 
 		it('keeps isRecording true when start() resolves and the signal is not aborted', async () => {
-			// Guard against regression: the post-hoc abort detection must not fire
-			// on a normal successful start.
-			mockStart.mockReturnValue(Promise.resolve())
+			// Guard against regression: the silent-resolve rollback must not fire
+			// on a normal successful start. Simulate vocal's real contract by
+			// dispatching 'start' from inside start() before resolution.
+			mockStart.mockImplementation(async () => {
+				mockOn.mock.calls
+					.filter(([type]) => type === 'start')
+					.forEach(([, handler]) => (handler as () => void)())
+			})
 			const controller = new AbortController() // not aborted
 			const { result } = renderHook(() => useVocal())
 			await act(async () => {
@@ -375,6 +391,12 @@ describe('useVocal', () => {
 		})
 
 		it('optimistically flips isRecording to true when start() is called', async () => {
+			// Simulate vocal's real contract: 'start' fires before start() resolves.
+			mockStart.mockImplementation(async () => {
+				mockOn.mock.calls
+					.filter(([type]) => type === 'start')
+					.forEach(([, handler]) => (handler as () => void)())
+			})
 			const { result } = renderHook(() => useVocal())
 			await act(async () => result.current[1].start())
 			expect(result.current[1].isRecording).toBe(true)

--- a/src/hooks/useVocal.ts
+++ b/src/hooks/useVocal.ts
@@ -66,10 +66,11 @@ export const useVocal = (
 		setIsRecording(true)
 		// vocal 2.x's start() can either reject (microphone/permission errors) or
 		// silently resolve without dispatching 'start' (AbortError on the signal —
-		// caught and swallowed internally). In both cases the instance never fires
-		// 'end'/'error', so the optimistic flag would stay stuck on `true`.
-		// Track the real 'start' event so a late signal abort that races a true
-		// success doesn't trigger a false rollback.
+		// caught and swallowed internally, or any other no-op resolution). In both
+		// cases the instance never fires 'end'/'error', so the optimistic flag would
+		// stay stuck on `true`. Track the real 'start' event so we can detect any
+		// silent resolution — independent of whether a signal was provided — while
+		// a late signal abort that races a true success does not trigger a false rollback.
 		let startEventFired = false
 		const onStart = () => {
 			startEventFired = true
@@ -77,7 +78,7 @@ export const useVocal = (
 		instance.on('start', onStart)
 		try {
 			await instance.start(options)
-			if (!startEventFired && options?.signal?.aborted) setIsRecording(false)
+			if (!startEventFired) setIsRecording(false)
 		} catch (err) {
 			setIsRecording(false)
 			throw err


### PR DESCRIPTION
## Summary
`useVocal.start()` previously rolled back the optimistic `isRecording = true` only when `options?.signal?.aborted` was true. If the underlying vocal library resolved silently (no `start` event dispatched) *without* an aborted signal, the optimistic flag stayed stuck on `true` forever. The fix drops the signal-aborted condition and rolls back whenever the `start` event did not fire during the call — the absence of the event is itself the canonical signal that the session did not begin.

## Changes
- `src/hooks/useVocal.ts`: rollback condition simplified to `if (!startEventFired)`. The race-protection contract (no false rollback when 'start' actually fired but a late abort comes in) is preserved because it is already guarded by the `startEventFired` flag.
- `src/hooks/__tests__/useVocal.test.ts`: two existing tests that documented the buggy behavior (`optimistically flips isRecording to true when start() is called`, `keeps isRecording true when start() resolves and the signal is not aborted`) updated to dispatch `'start'` from the mock, matching vocal's real contract. New regression test asserts the rollback fires on a silent resolve without signal.
- `README.md`: silent-abort note rewritten to describe the broader start-event-based detection.

## Test plan
- [x] `yarn test:ci` — 162/162 passing (1 new regression test, 2 updated to match the real vocal contract)
- [x] `yarn lint` — clean
- [x] `yarn typecheck` — clean
- [x] `yarn build` — ES + CJS bundles produced
- [x] `yarn dev` — demo starts and renders correctly

Closes #216