### PR TITLE
test(setup): Return a MediaStream-shaped stub from getUserMedia mock

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -16,7 +16,10 @@ const PermissionsMock = vi.fn(function () {
 })
 const MediaDevicesMock = vi.fn(function () {
 	return {
-		getUserMedia: vi.fn().mockResolvedValue('foo'),
+		getUserMedia: vi.fn().mockResolvedValue({
+			getTracks: () => [],
+			getAudioTracks: () => [],
+		}),
 	}
 })
 


### PR DESCRIPTION
## Summary
The `navigator.mediaDevices.getUserMedia` mock in `vitest.setup.ts` resolved to the placeholder string `'foo'`, which does not match the `MediaStream` contract. Current tests only check for resolution, so the issue is latent — any future code path that introspects the returned stream (`.getTracks()`, `.getAudioTracks()`, etc.) would silently misbehave or throw under test.

## Changes
- `vitest.setup.ts`: replace `mockResolvedValue('foo')` with a minimal MediaStream-shaped stub `{ getTracks: () => [], getAudioTracks: () => [] }`.

## Test plan
- [x] `yarn test:ci` — 162/162 passing
- [x] `yarn typecheck` — clean
- [x] `yarn lint` — clean
- [x] `yarn build` — ES + CJS bundles produced

Closes #218