### PR TITLE
refactor: Use null sentinel for the useTimeout timer ref

### DIFF
--- a/src/hooks/useTimeout.ts
+++ b/src/hooks/useTimeout.ts
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useRef } from 'react'
 
 export const useTimeout = (handler: () => void, timeout: number = 0): [start: () => void, stop: () => void] => {
-	const ref = useRef<ReturnType<typeof setTimeout> | number>(-1)
+	const ref = useRef<ReturnType<typeof setTimeout> | null>(null)
 
 	const stop = useCallback(() => {
-		clearTimeout(ref.current as ReturnType<typeof setTimeout>)
-		ref.current = -1
+		if (ref.current !== null) {
+			clearTimeout(ref.current)
+			ref.current = null
+		}
 	}, [])
 
 	const start = useCallback(() => {


### PR DESCRIPTION
## Summary
`useTimeout` initialised its timer ref to the literal `-1` typed as `ReturnType<typeof setTimeout> | number`, then called `clearTimeout(ref.current as ReturnType<typeof setTimeout>)` unconditionally. `clearTimeout(-1)` is a no-op in every JS runtime in practice, but it sends an invalid handle to the WHATWG timers API and the `as` cast was hiding the contract violation. This PR switches to a `null` sentinel and guards the cleanup.

## Changes
- `src/hooks/useTimeout.ts`:
  - Ref type tightened to `ReturnType<typeof setTimeout> | null`, initialised to `null`.
  - `stop()` guards on `ref.current !== null` before calling `clearTimeout`, then resets to `null`. The `as ReturnType<typeof setTimeout>` cast is gone.

No behavioural change for consumers — `[start, stop]` signature is identical and `clearTimeout(-1)` was already a no-op at runtime. The existing test suite (5 tests covering before-start, before-timeout, immediate, after-delay, and stop-before-timeout) continues to cover all branches.

## Test plan
- [x] `yarn test:ci` — 162/162 passing
- [x] `yarn typecheck` — clean (the new type is strictly narrower)
- [x] `yarn lint` — clean
- [x] `yarn build` — ES + CJS bundles produced

Closes #219