### PR TITLE
docs: fix README spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ timeout elapses.
 Some browsers support the `SpeechRecognition` API but not all the related APIs.  
 For example, on iOS 14.5, browsers do not support the `SpeechGrammar`, `SpeechGrammarList`, and `Permissions` APIs.
 
-Although the lack of `SpeechGrammar` and `SpeechGrammarList` is handled by the underlaying `@untemps/vocal` library, you need to deal with `Permissions` by yourself.
+Although the lack of `SpeechGrammar` and `SpeechGrammarList` is handled by the underlying `@untemps/vocal` library, you need to deal with `Permissions` by yourself.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Fix `underlaying` to `underlying` in the README Special cases section.

## Validation
- `rg -n 'underlaying|underlying|SpeechGrammar|Permissions' README.md`\n- `git diff --check`\n\nNo runtime tests were run because this is a README-only spelling fix.