### PR TITLE
docs: Update contributing commit guidelines link

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ Contributions are warmly welcomed:
 -   Create a feature branch (preferred name convention: `[feature type]_[imperative verb]-[description of the feature]`)
 -   Develop the feature AND write the tests (or write the tests AND develop the feature)
 -   Commit your changes
-    using [Angular Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines)
+    using [Conventional Commits](https://www.conventionalcommits.org/)
 -   Submit a Pull Request
 
 ## Roadmap


### PR DESCRIPTION
## Summary
- Replace the archived AngularJS commit guidelines link in the Contributing section with the Conventional Commits spec.
- Align the README guidance with this repo's `@commitlint/config-conventional` setup.

## Validation
- `rg -n "Angular Git Commit Guidelines|Conventional Commits|commitlint|config-conventional|Commit your changes" README.md package.json commitlint.config.js CLAUDE.md`
- `node -e 'const fs=require("fs"); JSON.parse(fs.readFileSync("package.json","utf8")); const c=require("./commitlint.config.js"); if(!c.extends.includes("@commitlint/config-conventional")) process.exit(1); console.log("package.json parses and commitlint uses @commitlint/config-conventional")'`
- `curl -L --max-time 20 -o /dev/null -s -w '%{http_code}\n' https://www.conventionalcommits.org/` returned `200`
- `git diff --check`

No runtime tests were run because this only updates a README reference link.
