### PR TITLE
feat: Update @untemps/vocal to 2.2.0 and expose microphone permission state

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,11 +211,12 @@ const App = () => {
 
 The following parameters are passed to the function:
 
-| Arguments | Type | Description                                                     |
-| --------- | ---- | --------------------------------------------------------------- |
-| start     | func | The function used to start the recognition                      |
-| stop      | func | The function used to stop the recognition                       |
-| isStarted | bool | A flag that indicates whether the recognition is started or not |
+| Arguments       | Type                       | Description                                                                                                   |
+| --------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| start           | func                       | The function used to start the recognition                                                                    |
+| stop            | func                       | The function used to stop the recognition                                                                     |
+| isStarted       | bool                       | A flag that indicates whether the recognition is started or not                                               |
+| permissionState | `PermissionState \| null` | Current microphone permission (`'granted'`/`'denied'`/`'prompt'`), tracked without starting a session. `null` until known or when the Permissions API is unavailable. See [Microphone permission](#microphone-permission). |
 
 ---
 
@@ -285,6 +286,7 @@ fuse.js is an optional peer dependency — install it separately to enable fuzzy
 | onResult      | func              | null                 | Handler called when a result is recognized                                                      |
 | onError       | func              | null                 | Handler called when an error occurs                                                             |
 | onNoMatch     | func              | null                 | Handler called when no result can be recognized                                                 |
+| onPermission  | func              | null                 | Handler called with the microphone `PermissionState` (`'granted'`/`'denied'`/`'prompt'`). Fires with the current state on mount — no `start()` needed — and again on every change. See [Microphone permission](#microphone-permission). |
 | signal        | AbortSignal       | null                 | Optional `AbortSignal` propagated to the underlying `start()` call. Aborting it cancels the in-flight start (e.g. while waiting for microphone permission). |
 
 > :warning: **Memoize non-primitive props.** A non-memoized `grammars` (constructed inline, e.g. `<Vocal grammars={new SpeechGrammarList()} />`) gets a new identity on every render and tears down and rebuilds the recognition instance each time — aborting in-flight sessions and churning microphone permissions. A non-memoized `commands` object similarly forces `useCommands` to re-normalize and re-index its fuzzy matcher on every render. Wrap such props in `useMemo` so their reference stays stable.
@@ -368,19 +370,20 @@ useVocal(lang, grammars, maxAlternatives, continuous)
 #### Return value
 
 ```
-const [ref, { start, stop, abort, subscribe, unsubscribe, clean, isRecording }]
+const [ref, { start, stop, abort, subscribe, unsubscribe, clean, isRecording, permissionState }]
 ```
 
-| Args        | Type | Description                                          |
-| ----------- | ---- | ---------------------------------------------------- |
-| ref         | Ref  | React ref to the underlying `@untemps/vocal` instance |
-| start       | func | Function to start the recognition. Accepts an optional `{ signal }` argument — an `AbortSignal` propagated to the underlying `start()` call. Returns a `Promise<void>` that resolves once the session starts and rejects with the original error on microphone/permission failures. |
-| stop        | func | Function to stop the recognition                     |
-| abort       | func | Function to abort the recognition                    |
-| subscribe   | func | Function to subscribe to recognition events          |
-| unsubscribe | func | Function to unsubscribe to recognition events        |
-| clean       | func | Function to remove all event listeners and clean up the recognition instance |
-| isRecording | bool | Reactive flag mirroring whether a session is active. `true` between `start()` and the next `end`/`error` event. Updated optimistically on `start()` so the UI re-renders at click time. |
+| Args            | Type                       | Description                                          |
+| --------------- | -------------------------- | ---------------------------------------------------- |
+| ref             | Ref                        | React ref to the underlying `@untemps/vocal` instance |
+| start           | func                       | Function to start the recognition. Accepts an optional `{ signal }` argument — an `AbortSignal` propagated to the underlying `start()` call. Returns a `Promise<void>` that resolves once the session starts and rejects with the original error on microphone/permission failures. |
+| stop            | func                       | Function to stop the recognition                     |
+| abort           | func                       | Function to abort the recognition                    |
+| subscribe       | func                       | Function to subscribe to recognition events          |
+| unsubscribe     | func                       | Function to unsubscribe to recognition events        |
+| clean           | func                       | Function to remove all event listeners and clean up the recognition instance |
+| isRecording     | bool                       | Reactive flag mirroring whether a session is active. `true` between `start()` and the next `end`/`error` event. Updated optimistically on `start()` so the UI re-renders at click time. |
+| permissionState | `PermissionState \| null` | Reactive microphone permission state. See [Microphone permission](#microphone-permission). |
 
 #### Cancelling a start in flight
 
@@ -396,7 +399,7 @@ const [, { start }] = useVocal('en-US')
 start({ signal: controller.signal })
 ```
 
-**Behavior note** — the underlying `@untemps/vocal` library currently swallows the `AbortError` internally: the promise returned by `start()` resolves silently rather than rejecting (see [untemps/vocal#129](https://github.com/untemps/vocal/issues/129)). `react-vocal` compensates by tracking whether the `start` event actually fired during the call and rolling `isRecording` back to `false` whenever it did not — regardless of whether a signal was provided — so consumers of `<Vocal>` or `useVocal` do not need any extra handling. If you bypass the hook and access the underlying `VocalInstance` via the ref returned by `useVocal`, you must observe the `start` event yourself to know when recognition truly began.
+**Behavior note** — the underlying `@untemps/vocal` library still swallows the `AbortError` internally (as of 2.2.0): the promise returned by `start()` resolves silently rather than rejecting (see [untemps/vocal#129](https://github.com/untemps/vocal/issues/129), where the reject-on-abort fix is targeted for the next major, 3.0.0). `react-vocal` compensates by tracking whether the `start` event actually fired during the call and rolling `isRecording` back to `false` whenever it did not — regardless of whether a signal was provided — so consumers of `<Vocal>` or `useVocal` do not need any extra handling. If you bypass the hook and access the underlying `VocalInstance` via the ref returned by `useVocal`, you must observe the `start` event yourself to know when recognition truly began.
 
 ### `useCommands` hook
 
@@ -472,12 +475,41 @@ const App = () => {
 | end         | Fired when the recognition service has disconnected                                       |
 | error       | Fired when a recognition error occurs                                                     |
 | nomatch     | Fired when the recognition service returns a final result with no significant recognition |
+| permission  | Fired with the current microphone `PermissionState` when first observed and on every change. The handler receives `(event, state)` where `state` is `'granted'`/`'denied'`/`'prompt'`. See [Microphone permission](#microphone-permission). |
 | result      | Fired when the recognition service returns a result                                       |
 | soundend    | Fired when any sound — recognisable or not — has stopped being detected                   |
 | soundstart  | Fired when any sound — recognisable or not — has been detected                            |
 | speechend   | Fired when speech recognized by the recognition service has stopped being detected        |
 | speechstart | Fired when sound recognized by the recognition service as speech has been detected        |
 | start       | fired when the recognition service has begun listening to incoming audio                  |
+
+### Microphone permission
+
+Since `@untemps/vocal` 2.2, `react-vocal` surfaces the microphone permission state **without starting a recognition session** (no `getUserMedia` prompt). `useVocal` begins watching `navigator.permissions` at mount and exposes the result reactively as `permissionState` — and the `Vocal` component forwards it through the `onPermission` prop and the fourth argument of the children function. The value is `'granted'`, `'denied'`, `'prompt'`, or `null` while still unknown (or when the Permissions API is unavailable, e.g. some browsers or SSR).
+
+Use it to gate the UI before the user ever clicks — for example, to hide the button or show guidance when access is already denied:
+
+```javascript
+import { Vocal } from '@untemps/react-vocal'
+
+const App = () => (
+	<Vocal onPermission={(state) => console.log('microphone permission:', state)}>
+		{(start, stop, isStarted, permissionState) =>
+			permissionState === 'denied' ? (
+				<p>Microphone access is blocked — enable it in your browser settings.</p>
+			) : (
+				<button onClick={isStarted ? stop : start}>{isStarted ? 'Stop' : 'Start'}</button>
+			)
+		}
+	</Vocal>
+)
+```
+
+With the `useVocal` hook the same state is available directly:
+
+```javascript
+const [, { start, permissionState }] = useVocal('en-US')
+```
 
 ### Notes
 

--- a/dev/src/index.jsx
+++ b/dev/src/index.jsx
@@ -14,6 +14,7 @@ const App = () => {
 	const [logs, setLogs] = useState('')
 	const [borderColor, setBorderColor] = useState()
 	const [continuous, setContinuous] = useState(false)
+	const [permission, setPermission] = useState(null)
 
 	const _log = (value) => setLogs((prev) => `${prev}${prev.length > 0 ? '\n' : ''} ----- ${value}`)
 
@@ -42,8 +43,15 @@ const App = () => {
 				onEnd={() => _log('end')}
 				onResult={(result) => _log(`transcript: "${result}"`)}
 				onError={(e) => _log(`error: ${e.message}`)}
+				onPermission={(state) => {
+					setPermission(state)
+					_log(`permission: ${state}`)
+				}}
 				maxAlternatives={3}
 			/>
+			<p style={{ fontSize: 12, color: '#666', margin: '8px 0' }}>
+				Permission micro : <code>{permission ?? 'inconnue'}</code>
+			</p>
             <p style={{ fontSize: 12, color: '#666', margin: '8px 0' }}>
               <label style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
                 <input type="checkbox" checked={continuous} onChange={(e) => setContinuous(e.target.checked)} />

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
 		}
 	},
 	"dependencies": {
-		"@untemps/vocal": "^2.0.1"
+		"@untemps/vocal": "^2.2.0"
 	},
 	"release": {
 		"branches": [

--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -2,6 +2,7 @@ import {
 	cloneElement,
 	isValidElement,
 	useCallback,
+	useEffect,
 	useMemo,
 	useRef,
 	type CSSProperties,
@@ -75,7 +76,14 @@ export const classifyError = (err: unknown): VocalError => {
 }
 
 export interface VocalProps {
-	children?: ReactNode | ((start: () => void, stop: () => void, isStarted: boolean) => ReactElement | null)
+	children?:
+		| ReactNode
+		| ((
+				start: () => void,
+				stop: () => void,
+				isStarted: boolean,
+				permissionState: PermissionState | null
+		  ) => ReactElement | null)
 	commands?: CommandsMap | null
 	lang?: string
 	grammars?: SpeechGrammarList | null
@@ -95,6 +103,7 @@ export interface VocalProps {
 	onResult?: OnResultCallback | null
 	onError?: OnErrorCallback | null
 	onNoMatch?: ((event: Event) => void) | null
+	onPermission?: ((state: PermissionState) => void) | null
 	signal?: AbortSignal | null
 }
 
@@ -131,12 +140,13 @@ export const Vocal = ({
 	onResult = null,
 	onError = null,
 	onNoMatch = null,
+	onPermission = null,
 	signal = null,
 }: VocalProps) => {
 	const buttonRef = useRef<HTMLButtonElement | null>(null)
 	const isSupported = useMemo(() => isSupportedFn(), [])
 
-	const [, { start, stop, subscribe, unsubscribe, isRecording: isListening }] = useVocal(
+	const [, { start, stop, subscribe, unsubscribe, isRecording: isListening, permissionState }] = useVocal(
 		lang,
 		grammars,
 		maxAlternatives,
@@ -152,6 +162,7 @@ export const Vocal = ({
 		onResult: VocalProps['onResult']
 		onError: VocalProps['onError']
 		onNoMatch: VocalProps['onNoMatch']
+		onPermission: VocalProps['onPermission']
 	}>({
 		onStart: null,
 		onEnd: null,
@@ -160,8 +171,13 @@ export const Vocal = ({
 		onResult: null,
 		onError: null,
 		onNoMatch: null,
+		onPermission: null,
 	})
-	propsRef.current = { onStart, onEnd, onSpeechStart, onSpeechEnd, onResult, onError, onNoMatch }
+	propsRef.current = { onStart, onEnd, onSpeechStart, onSpeechEnd, onResult, onError, onNoMatch, onPermission }
+
+	useEffect(() => {
+		if (permissionState !== null) propsRef.current.onPermission?.(permissionState)
+	}, [permissionState])
 
 	const fireError = useCallback((err: unknown) => {
 		propsRef.current.onError?.(classifyError(err))
@@ -353,11 +369,14 @@ export const Vocal = ({
 	const _renderChildren = () => {
 		if (isSupported) {
 			if (isFunction(children)) {
-				return (children as (start: () => void, stop: () => void, isStarted: boolean) => ReactElement | null)(
-					startRecognition,
-					stopRecognition,
-					isListening
-				)
+				return (
+					children as (
+						start: () => void,
+						stop: () => void,
+						isStarted: boolean,
+						permissionState: PermissionState | null
+					) => ReactElement | null
+				)(startRecognition, stopRecognition, isListening, permissionState)
 			} else if (isValidElement(children)) {
 				const typed = children as ReactElement<{
 					onClick?: (e: ReactMouseEvent) => void

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -232,6 +232,35 @@ describe('Vocal', () => {
 		})
 	})
 
+	describe('Microphone permission', () => {
+		it('fires onPermission with the current state on mount, without starting recognition', async () => {
+			const onPermission = vi.fn()
+			const recognition = createMockVocal({ initialPermission: 'granted' })
+			render(getInstance({ __rsInstance: recognition, onPermission }))
+			await waitFor(() => expect(onPermission).toHaveBeenCalledWith('granted'))
+			expect(recognition.start).not.toHaveBeenCalled()
+		})
+
+		it('fires onPermission again when the permission state changes', async () => {
+			const onPermission = vi.fn()
+			const recognition = createMockVocal({ initialPermission: 'prompt' })
+			render(getInstance({ __rsInstance: recognition, onPermission }))
+			await waitFor(() => expect(onPermission).toHaveBeenCalledWith('prompt'))
+			await act(async () => recognition.permission('denied'))
+			expect(onPermission).toHaveBeenLastCalledWith('denied')
+		})
+
+		it('passes the permission state as the fourth argument of the children function', async () => {
+			const recognition = createMockVocal({ initialPermission: 'denied' })
+			const { queryByText } = render(
+				getInstance({ __rsInstance: recognition }, (_start, _stop, _isStarted, permissionState) => (
+					<div>{permissionState ?? 'unknown'}</div>
+				))
+			)
+			await waitFor(() => expect(queryByText('denied')).toBeInTheDocument())
+		})
+	})
+
 	it.each<[label: string, continuous: boolean, clickToListen: boolean]>([
 		['idle', false, false],
 		['listening in non-continuous mode', false, true],

--- a/src/components/__tests__/createMockVocal.ts
+++ b/src/components/__tests__/createMockVocal.ts
@@ -30,6 +30,7 @@ const pickBest = (alternatives: Segment): string => {
 
 export interface MockVocalOptions {
 	continuous?: boolean
+	initialPermission?: PermissionState
 }
 
 export type MockVocalInput = string | Segment[] | null | undefined
@@ -51,8 +52,12 @@ export interface MockVocalInstance extends Omit<VocalInstance, 'start' | 'stop' 
 	say: (input: MockVocalInput) => void
 	error: (err: unknown) => void
 	end: () => void
+	permission: (state: PermissionState) => void
 	handlerCount: () => number
 }
+
+const buildPermissionEvent = (state: PermissionState): Event & { state: PermissionState } =>
+	Object.assign(new Event('permission'), { state })
 
 // Mock VocalInstance for component tests — implements the contract of
 // `createVocal()` from @untemps/vocal 2.x and exposes test helpers
@@ -74,6 +79,7 @@ export const createMockVocal = (options: MockVocalOptions = {}): MockVocalInstan
 	let isRecording = false
 	const accumulated: Segment[] = []
 	const continuous = !!options.continuous
+	const { initialPermission } = options
 
 	const fire = (type: string, ...args: unknown[]) => {
 		const cbs = handlers[type]
@@ -112,6 +118,9 @@ export const createMockVocal = (options: MockVocalOptions = {}): MockVocalInstan
 		on: vi.fn((type: string, cb: (...args: unknown[]) => void) => {
 			if (!handlers[type]) handlers[type] = []
 			handlers[type].push(cb)
+			if (type === 'permission' && initialPermission !== undefined) {
+				cb(buildPermissionEvent(initialPermission), initialPermission)
+			}
 		}),
 		off: vi.fn((type: string, cb?: (...args: unknown[]) => void) => {
 			if (!handlers[type]) return
@@ -151,6 +160,9 @@ export const createMockVocal = (options: MockVocalOptions = {}): MockVocalInstan
 		},
 		end() {
 			fire('end', new Event('end'))
+		},
+		permission(state: PermissionState) {
+			fire('permission', buildPermissionEvent(state), state)
 		},
 		handlerCount() {
 			return Object.values(handlers).reduce((sum, arr) => sum + arr.length, 0)

--- a/src/hooks/__tests__/useVocal.test.ts
+++ b/src/hooks/__tests__/useVocal.test.ts
@@ -409,8 +409,29 @@ describe('useVocal', () => {
 			expect(mockOff).toHaveBeenCalledWith('start', expect.any(Function))
 			expect(mockOff).toHaveBeenCalledWith('end', expect.any(Function))
 			expect(mockOff).toHaveBeenCalledWith('error', expect.any(Function))
+			expect(mockOff).toHaveBeenCalledWith('permission', expect.any(Function))
 			expect(mockAbort).toHaveBeenCalledTimes(1)
 			expect(mockCleanup).toHaveBeenCalledTimes(1)
+		})
+
+		it('subscribes to the permission event on mount', () => {
+			renderHook(() => useVocal())
+			expect(mockOn).toHaveBeenCalledWith('permission', expect.any(Function))
+		})
+
+		it('exposes permissionState as null initially', () => {
+			const { result } = renderHook(() => useVocal())
+			expect(result.current[1].permissionState).toBeNull()
+		})
+
+		it('updates permissionState when the permission event fires', async () => {
+			const { result } = renderHook(() => useVocal())
+			const permissionCallback = mockOn.mock.calls.find(([type]) => type === 'permission')![1] as (
+				event: Event,
+				state: PermissionState
+			) => void
+			await act(async () => permissionCallback(new Event('permission'), 'denied'))
+			expect(result.current[1].permissionState).toBe('denied')
 		})
 
 		it('tears down and recreates the instance when lang changes', () => {
@@ -426,7 +447,7 @@ describe('useVocal', () => {
 
 			expect(createVocal).toHaveBeenCalledTimes(2)
 			expect(createVocal).toHaveBeenLastCalledWith(expect.objectContaining({ lang: 'fr-FR' }))
-			expect(mockOff.mock.calls.length).toBe(offCallsBefore + 3)
+			expect(mockOff.mock.calls.length).toBe(offCallsBefore + 4)
 			expect(mockAbort).toHaveBeenCalledTimes(1)
 			expect(mockCleanup).toHaveBeenCalledTimes(1)
 		})

--- a/src/hooks/useVocal.ts
+++ b/src/hooks/useVocal.ts
@@ -22,6 +22,7 @@ export interface UseVocalActions {
 	}
 	clean: () => void
 	isRecording: boolean
+	permissionState: PermissionState | null
 }
 
 export type UseVocalReturn = [RefObject<VocalInstance | null>, UseVocalActions]
@@ -34,6 +35,7 @@ export const useVocal = (
 ): UseVocalReturn => {
 	const ref = useRef<VocalInstance | null>(null)
 	const [isRecording, setIsRecording] = useState(false)
+	const [permissionState, setPermissionState] = useState<PermissionState | null>(null)
 	const supported = useMemo(() => isSupported(), [])
 
 	useEffect(() => {
@@ -47,13 +49,18 @@ export const useVocal = (
 			instance.on('end', handleStop)
 			instance.on('error', handleStop)
 
+			const handlePermission: EventHandlerFor<'permission'> = (_event, state) => setPermissionState(state)
+			instance.on('permission', handlePermission)
+
 			return () => {
 				instance.off('start', handleStart)
 				instance.off('end', handleStop)
 				instance.off('error', handleStop)
+				instance.off('permission', handlePermission)
 				instance.abort()
 				instance.cleanup()
 				setIsRecording(false)
+				setPermissionState(null)
 			}
 		}
 	}, [lang, grammars, maxAlternatives, continuous, supported])
@@ -123,5 +130,5 @@ export const useVocal = (
 		}
 	}, [])
 
-	return [ref, { start, stop, abort, subscribe, unsubscribe, clean, isRecording }]
+	return [ref, { start, stop, abort, subscribe, unsubscribe, clean, isRecording, permissionState }]
 }

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -7,6 +7,7 @@ const PermissionStatusMock = vi.fn(function () {
 	return {
 		state: 'granted',
 		addEventListener: vi.fn(),
+		removeEventListener: vi.fn(),
 	}
 })
 const PermissionsMock = vi.fn(function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1383,22 +1383,22 @@
     "@typescript-eslint/types" "8.59.4"
     eslint-visitor-keys "^5.0.0"
 
-"@untemps/user-permissions-utils@^1.3.3":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@untemps/user-permissions-utils/-/user-permissions-utils-1.3.4.tgz#f7e66f4e5f77d47a5e7f4c2e4b2d3db83f79a8fa"
-  integrity sha512-pVZ8S4EGWugDUf74cwsHs8TO7aheBqKFyqdIS33wIVEqxuo4S7anDtdwg/gFDx7RZ6LoQ6Mi3Iz3T2wsJu6JKw==
+"@untemps/user-permissions-utils@^2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@untemps/user-permissions-utils/-/user-permissions-utils-2.2.3.tgz#32d09618549b3b93f927850a9474401e49632b58"
+  integrity sha512-1qdITXQAI9hMNxUay1Sx4M13Ffuz8MABHI5T6Xkf3wTIYhZHBZQVHAKIhsI30jcBVx6jl68wObfjz9q0Vhu3xQ==
 
 "@untemps/utils@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@untemps/utils/-/utils-3.2.0.tgz#dc26d65d54e4a5e9b940b5c7f65832f60ff283dd"
   integrity sha512-P48fcASTI8LSngn8cYjDq8KkasjDLghOnDmMatjwTLp0/qwp8/sifYuAJDODCqXXr7xATxcTnkULzNdZqavuNA==
 
-"@untemps/vocal@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@untemps/vocal/-/vocal-2.0.1.tgz#67b45c70817f07d355ce1aa029220ae6c8a2a3c1"
-  integrity sha512-TBRxtkzA2d7/RHkDIHBUf9WUiPPZKrLjB4sfVluWbfuO1MPpBqchg0TaJCtMjiYwbI56sdbM2VHtZjSk4xfmlA==
+"@untemps/vocal@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@untemps/vocal/-/vocal-2.2.0.tgz#bccc70ce4e813ff6544afccdf0e61963b4bf147f"
+  integrity sha512-pZrrUjCmUX9mVKeRjAHRhK0n6vKA+3BrimuXmPQgT4jkZxatKAcc53/z0Now3J2c2WKiWBd3n96VVUfCxD2UBQ==
   dependencies:
-    "@untemps/user-permissions-utils" "^1.3.3"
+    "@untemps/user-permissions-utils" "^2.2.3"
 
 "@vitejs/plugin-react@^6.0.1":
   version "6.0.1"


### PR DESCRIPTION
## Contexte

Mise à jour de `@untemps/vocal` `2.0.1 → 2.2.0` (saut mineur, non-breaking — les ruptures dataient de 2.0.0, déjà passé) et exploitation de ses nouveautés.

## Changements

### `chore(deps)` — bump `@untemps/vocal` 2.0.1 → 2.2.0
- Tire `@untemps/user-permissions-utils@2.2.3` (transitif).
- Notes de version : 2.1.0 (migration interne user-permissions-utils v2), 2.2.0 (état de permission micro hors session `start()`).

### `feat` — Exposition de l'état de permission micro (vocal 2.2)
Surface le `PermissionState` du micro **sans démarrer de session** (`granted` / `denied` / `prompt`), donc sans prompt `getUserMedia`.

- **`useVocal`** : abonnement à l'événement `permission` au montage → expose un `permissionState` réactif.
- **`<Vocal>`** : nouvelle prop `onPermission` + `permissionState` en **4ᵉ argument** du render-prop (rétrocompatible).
- **`createMockVocal`** : option `initialPermission` (mirroir de l'`emitImmediately`) + helper `permission(state)`.
- **`vitest.setup`** : le mock `PermissionStatus` expose `removeEventListener` (sinon le teardown du watcher lève une `TypeError`).
- **Démo** : affiche et logue l'état de permission en direct.
- **README** : section *Microphone permission*, tables props/actions/events et exemple.

### Issue #129 (AbortError)
Confirmé dans le code compilé de 2.2.0 : `start()` **avale toujours** l'`AbortError` et retourne en silence sur signal aborté. [untemps/vocal#129](https://github.com/untemps/vocal/issues/129) reste **ouverte** (fix reject-on-abort ciblé pour la v3.0.0). → Le workaround dans `useVocal` reste nécessaire ; note du README précisée.

## Validation
- typecheck ✓
- lint ✓
- tests **168/168** ✓ (6 nouveaux, 0 erreur)
- couverture 98.5% stmts / 92.5% branches (seuils 90/85) ✓
- build lib ✓ + build démo ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)