### PR TITLE
perf: Normalize commands in linear time in useCommands

### DIFF
--- a/src/hooks/__tests__/useCommands.test.ts
+++ b/src/hooks/__tests__/useCommands.test.ts
@@ -85,6 +85,16 @@ describe('useCommands', () => {
 		})
 	})
 
+	it('normalizes command keys to lowercase so mixed-case keys match lowercase input', () => {
+		const commands = {
+			Foo: () => 'bar',
+		}
+		const {
+			result: { current: triggerCommand },
+		} = renderHook(() => useCommands(commands))
+		expect(triggerCommand('foo')).toBe('bar')
+	})
+
 	it('returns null as no command is mapped to the input', () => {
 		const commands = {
 			foo: () => 'bar',

--- a/src/hooks/useCommands.ts
+++ b/src/hooks/useCommands.ts
@@ -11,10 +11,7 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 	const normalized = useMemo<CommandsMap>(
 		() =>
 			commands
-				? Object.entries(commands).reduce<CommandsMap>(
-						(acc, [key, value]) => ({ ...acc, [key.toLowerCase()]: value }),
-						{}
-					)
+				? Object.fromEntries(Object.entries(commands).map(([key, value]) => [key.toLowerCase(), value]))
 				: {},
 		[commands]
 	)


### PR DESCRIPTION
## Summary
`useCommands` normalised the commands map with a `reduce` that spreads the accumulator on every iteration (`{ ...acc, [k]: v }`), which is O(n²) on the number of commands. This replaces it with `Object.fromEntries` over the lowercased entries — linear, with identical behaviour (last key wins on case-insensitive collision).

## Changes
- `src/hooks/useCommands.ts` — build the normalized map via `Object.fromEntries(Object.entries(commands).map(...))` instead of the spread reducer.
- `src/hooks/__tests__/useCommands.test.ts` — add a test locking in case-insensitive key normalization (a `Foo` key matches `foo` input).

## Test plan
- [x] `yarn test:ci` — all tests green (169 passed)
- [x] `yarn build` — builds without error
- [x] `yarn typecheck` — no type errors
- [x] `yarn lint` — no lint errors

## Breaking changes
None. Pure internal refactor; public API and behaviour are unchanged.

Closes #220