### PR TITLE
docs: Use exposed isRecording flag in useVocal example

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,37 +296,41 @@ fuse.js is an optional peer dependency — install it separately to enable fuzzy
 #### Basic usage
 
 ```javascript
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useVocal } from '@untemps/react-vocal'
 import Icon from './Icon'
 
 const App = () => {
-	const [isListening, setIsListening] = useState(false)
 	const [result, setResult] = useState('')
 
-	const [, { start, subscribe }] = useVocal('fr-FR')
+	const [, { start, subscribe, unsubscribe, isRecording }] = useVocal('fr-FR')
 
-	const _onButtonClick = () => {
-		setIsListening(true)
+	useEffect(() => {
+		const _onVocalStart = () => {
+			setResult('')
+		}
+
+		const _onVocalResult = (_event, bestAlternative) => {
+			setResult(bestAlternative)
+		}
+
+		const _onVocalError = (e) => {
+			console.error(e)
+		}
 
 		subscribe('speechstart', _onVocalStart)
 		subscribe('result', _onVocalResult)
 		subscribe('error', _onVocalError)
+
+		return () => {
+			unsubscribe('speechstart', _onVocalStart)
+			unsubscribe('result', _onVocalResult)
+			unsubscribe('error', _onVocalError)
+		}
+	}, [subscribe, unsubscribe])
+
+	const _onButtonClick = () => {
 		start()
-	}
-
-	const _onVocalStart = () => {
-		setResult('')
-	}
-
-	const _onVocalResult = (_event, bestAlternative) => {
-		setIsListening(false)
-
-		setResult(bestAlternative)
-	}
-
-	const _onVocalError = (e) => {
-		console.error(e)
 	}
 
 	return (
@@ -339,7 +343,7 @@ const App = () => {
 					style={{ width: 16, position: 'absolute', right: 10, top: 2 }}
 					onClick={_onButtonClick}
 				>
-					<Icon color={isListening ? 'red' : 'blue'} />
+					<Icon color={isRecording ? 'red' : 'blue'} />
 				</div>
 				<input defaultValue={result} style={{ width: 300, height: 40 }} />
 			</span>


### PR DESCRIPTION
## Summary
The `useVocal` basic-usage example in the README maintained its own `isListening` state and re-subscribed event handlers on every click without ever unsubscribing. The hook already exposes a reactive `isRecording` flag, so the example now consumes it directly and manages subscriptions safely.

## Changes
- Drop the local `isListening` state in favor of the exposed `isRecording` flag.
- Destructure `isRecording` and `unsubscribe` from the `useVocal` return value.
- Move the `speechstart` / `result` / `error` subscriptions into a `useEffect` that unsubscribes on cleanup, fixing the handler leak across clicks.
- Simplify the button click handler to just call `start()`.

## Test plan
- [ ] README example reads correctly and reflects the current hook API (`isRecording`, `subscribe`/`unsubscribe`).
- [ ] `yarn lint` passes (no source changes; documentation only).

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)