### PR TITLE
docs: Make README Testing mock start return a Promise to match VocalInstance contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ vi.mock('@untemps/vocal', async (importOriginal) => {
 const buildMockVocal = () => {
 	const handlers: Record<string, ((...args: unknown[]) => void)[]> = {}
 	return {
-		start: vi.fn(),
+		start: vi.fn(async () => {}),
 		stop: vi.fn(),
 		abort: vi.fn(),
 		cleanup: vi.fn(),


### PR DESCRIPTION
## Summary
The README "Testing" section's `buildMockVocal` helper declared `start: vi.fn()`, which TypeScript infers as `() => undefined`. This fails the `satisfies VocalInstance` constraint under strict TypeScript and does not match the runtime contract `useVocal` relies on — `VocalInstance.start` is `(options?) => Promise<void>` and `useVocal` does `await instance.start(options)`.

This aligns the example with the real contract (and with the repository's own `createMockVocal` test helper, which already uses `vi.fn(async () => {})`).

## Changes
- `README.md` — change `start: vi.fn()` to `start: vi.fn(async () => {})` in the `buildMockVocal` example so the mock returns a resolved `Promise<void>`.

## Test plan
- [x] `yarn typecheck` (tsc --noEmit) passes
- [x] `yarn lint` passes
- [x] `yarn test:ci` passes (169 tests)
- [ ] Copy the README example into a strict-TS test file and confirm `satisfies VocalInstance` no longer errors

Closes #222