### PR TITLE
docs: Remove outdated README Roadmap section

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,7 +627,3 @@ Contributions are warmly welcomed:
 -   Commit your changes
     using [Angular Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines)
 -   Submit a Pull Request
-
-## Roadmap
-
--   Add a connector management to plug external speech-to-text services in


### PR DESCRIPTION
## Summary
The README `## Roadmap` section listed a single stale bullet ("Add a connector management to plug external speech-to-text services in") that predates the entire 2.x feature set and no longer reflects shipped work (continuous mode, error classification, `signal` cancellation, exported `useCommands`, named-only exports, microphone permission state, etc.).

Planned work and feature requests are already tracked in the [GitHub issue tracker](https://github.com/untemps/react-vocal/issues), which makes the section redundant. Per the maintainer's call on #223, the section is removed rather than rewritten — avoiding a hand-maintained list that would only go stale again.

## Changes
- Remove the `## Roadmap` heading and its lone bullet from `README.md`; the README now ends on the `## Contributing` section. No other references to "Roadmap" exist in the doc (no TOC/anchor links to fix).

## Test plan
- [x] `yarn lint` — passes
- [x] `yarn typecheck` — passes
- [x] `yarn test:ci` — 169 tests pass
- [x] `yarn build` — ESM + CJS build succeeds
- [x] Visually confirm rendered README ends cleanly after Contributing

Closes #223