### PR TITLE
docs: Replace archived Angular Git Commit Guidelines link

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,5 +625,5 @@ Contributions are warmly welcomed:
 -   Create a feature branch (preferred name convention: `[feature type]_[imperative verb]-[description of the feature]`)
 -   Develop the feature AND write the tests (or write the tests AND develop the feature)
 -   Commit your changes
-    using [Angular Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines)
+    using [Conventional Commits](https://www.conventionalcommits.org/)
 -   Submit a Pull Request


### PR DESCRIPTION
## Summary
The Contributing section linked to `angular/angular.js/blob/master/DEVELOPERS.md`, which is archived. This replaces it with the [Conventional Commits](https://www.conventionalcommits.org/) specification — exactly what the project's `commitlint` setup (`@commitlint/config-conventional`) enforces.

## Changes
- `README.md` — Update the Contributing commit-guidelines link to point to the Conventional Commits spec.

## Test plan
- [ ] Open the rendered README and confirm the "Commit your changes using Conventional Commits" link resolves to https://www.conventionalcommits.org/

Closes #224