### PR TITLE
fix(vocal): Default button has no aria-busy feedback during getUserMedia permission resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,9 @@ To cancel the toggle (e.g. require a confirmation, block while the user is unaut
 
 For accessibility parity with the default button, `aria-pressed` is also injected on the cloned child to reflect
 the listening state, and `aria-label` falls back to the `ariaLabel` prop of `<Vocal>` when the child does not
-declare one of its own.
+declare one of its own. `aria-busy` is injected as well: it switches to `"true"` for the pending window between
+the click and the `start` event — while the browser resolves the microphone permission — so assistive tech
+announces that the click was registered before recognition actually begins.
 
 -   With a function that returns a React element:
 
@@ -374,7 +376,7 @@ useVocal(lang, grammars, maxAlternatives, continuous)
 #### Return value
 
 ```
-const [ref, { start, stop, abort, subscribe, unsubscribe, clean, isRecording, permissionState }]
+const [ref, { start, stop, abort, subscribe, unsubscribe, clean, isRecording, isStarting, permissionState }]
 ```
 
 | Args            | Type                       | Description                                          |
@@ -387,6 +389,7 @@ const [ref, { start, stop, abort, subscribe, unsubscribe, clean, isRecording, pe
 | unsubscribe     | func                       | Function to unsubscribe to recognition events        |
 | clean           | func                       | Function to remove all event listeners and clean up the recognition instance |
 | isRecording     | bool                       | Reactive flag mirroring whether a session is active. `true` between `start()` and the next `end`/`error` event. Updated optimistically on `start()` so the UI re-renders at click time. |
+| isStarting      | bool                       | Reactive flag for the pending window between `start()` and the real `start` event — while the browser resolves the microphone permission (`getUserMedia`). `true` from the click until `start` fires, then `false`; also cleared if the start is aborted or rejected. Use it to surface a busy/spinner state distinct from the active `isRecording` listening state. |
 | permissionState | `PermissionState \| null` | Reactive microphone permission state. See [Microphone permission](#microphone-permission). |
 
 #### Cancelling a start in flight

--- a/README.md
+++ b/README.md
@@ -168,7 +168,9 @@ For accessibility parity with the default button, `aria-pressed` is also injecte
 the listening state, and `aria-label` falls back to the `ariaLabel` prop of `<Vocal>` when the child does not
 declare one of its own. `aria-busy` is injected as well: it switches to `"true"` for the pending window between
 the click and the `start` event — while the browser resolves the microphone permission — so assistive tech
-announces that the click was registered before recognition actually begins.
+announces that the click was registered before recognition actually begins. During that pending window
+`aria-pressed` stays `"false"` and only flips to `"true"` once the `start` event fires, so the pressed state
+reflects real listening rather than the optimistic pending state.
 
 -   With a function that returns a React element:
 

--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -338,12 +338,18 @@ export const Vocal = ({
 		}
 	}, [className, outlineStyle])
 
+	// aria-pressed reflects the *real* listening state. During the optimistic
+	// start window (isStarting) the button is busy resolving the microphone
+	// permission and is not pressed yet, so we hold it false until 'start' fires
+	// — otherwise it would announce as pressed before recognition has begun.
+	const isPressed = isListening && !isStarting
+
 	const _renderDefault = () => (
 		<button
 			data-testid="__vocal-root__"
 			ref={buttonRef}
 			aria-label={ariaLabel}
-			aria-pressed={isListening}
+			aria-pressed={isPressed}
 			aria-busy={isStarting}
 			style={
 				className
@@ -393,7 +399,7 @@ export const Vocal = ({
 						if (e.defaultPrevented) return
 						;(isListening ? stopRecognition : startRecognition)()
 					},
-					'aria-pressed': isListening,
+					'aria-pressed': isPressed,
 					'aria-busy': isStarting,
 					'aria-label': childAriaLabel ?? ariaLabel,
 				})

--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -146,7 +146,7 @@ export const Vocal = ({
 	const buttonRef = useRef<HTMLButtonElement | null>(null)
 	const isSupported = useMemo(() => isSupportedFn(), [])
 
-	const [, { start, stop, subscribe, unsubscribe, isRecording: isListening, permissionState }] = useVocal(
+	const [, { start, stop, subscribe, unsubscribe, isRecording: isListening, isStarting, permissionState }] = useVocal(
 		lang,
 		grammars,
 		maxAlternatives,
@@ -344,6 +344,7 @@ export const Vocal = ({
 			ref={buttonRef}
 			aria-label={ariaLabel}
 			aria-pressed={isListening}
+			aria-busy={isStarting}
 			style={
 				className
 					? undefined
@@ -381,6 +382,7 @@ export const Vocal = ({
 				const typed = children as ReactElement<{
 					onClick?: (e: ReactMouseEvent) => void
 					'aria-pressed'?: boolean
+					'aria-busy'?: boolean
 					'aria-label'?: string
 				}>
 				const childOnClick = typed.props.onClick
@@ -392,6 +394,7 @@ export const Vocal = ({
 						;(isListening ? stopRecognition : startRecognition)()
 					},
 					'aria-pressed': isListening,
+					'aria-busy': isStarting,
 					'aria-label': childAriaLabel ?? ariaLabel,
 				})
 			} else {

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -150,6 +150,30 @@ describe('Vocal', () => {
 		expect(getByTestId('__vocal-custom-root__')).toHaveAttribute('aria-pressed', 'false')
 	})
 
+	it('propagates aria-busy=false on the cloned child while idle', () => {
+		const { getByTestId } = render(getInstance(null, <button data-testid="__vocal-custom-root__" />))
+		expect(getByTestId('__vocal-custom-root__')).toHaveAttribute('aria-busy', 'false')
+	})
+
+	it('sets aria-busy on the cloned child while the start is pending, then clears it once recognition starts', async () => {
+		const recognition = createMockVocal()
+		recognition.start.mockImplementation(() => new Promise<void>(() => {}))
+		const { getByTestId } = render(
+			getInstance({ __rsInstance: recognition }, <button data-testid="__vocal-custom-root__" />)
+		)
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-custom-root__'))
+		})
+		expect(getByTestId('__vocal-custom-root__')).toHaveAttribute('aria-busy', 'true')
+
+		await act(async () => {
+			recognition.fire('start', new Event('start'))
+		})
+		expect(getByTestId('__vocal-custom-root__')).toHaveAttribute('aria-busy', 'false')
+		expect(getByTestId('__vocal-custom-root__')).toHaveAttribute('aria-pressed', 'true')
+	})
+
 	it('falls back to the ariaLabel prop on the cloned child when the child has no aria-label', () => {
 		const { getByTestId } = render(
 			getInstance({ ariaLabel: 'start mic' }, <button data-testid="__vocal-custom-root__" />)
@@ -274,6 +298,28 @@ describe('Vocal', () => {
 	it('sets aria-pressed when listening', () => {
 		const { getByTestId } = render(getInstance())
 		fireEvent.click(getByTestId('__vocal-root__'))
+		expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-pressed', 'true')
+	})
+
+	it('renders aria-busy=false on the default button while idle', () => {
+		const { getByTestId } = render(getInstance())
+		expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-busy', 'false')
+	})
+
+	it('sets aria-busy on the default button while the start is pending, then clears it once recognition starts', async () => {
+		const recognition = createMockVocal()
+		recognition.start.mockImplementation(() => new Promise<void>(() => {}))
+		const { getByTestId } = render(getInstance({ __rsInstance: recognition }))
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+		})
+		expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-busy', 'true')
+
+		await act(async () => {
+			recognition.fire('start', new Event('start'))
+		})
+		expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-busy', 'false')
 		expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-pressed', 'true')
 	})
 

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -166,6 +166,8 @@ describe('Vocal', () => {
 			fireEvent.click(getByTestId('__vocal-custom-root__'))
 		})
 		expect(getByTestId('__vocal-custom-root__')).toHaveAttribute('aria-busy', 'true')
+		// pressed is gated on the real listening state, not the optimistic start window
+		expect(getByTestId('__vocal-custom-root__')).toHaveAttribute('aria-pressed', 'false')
 
 		await act(async () => {
 			recognition.fire('start', new Event('start'))
@@ -295,9 +297,14 @@ describe('Vocal', () => {
 		expect(getByTestId('__vocal-root__')).toHaveStyle({ cursor: 'pointer' })
 	})
 
-	it('sets aria-pressed when listening', () => {
-		const { getByTestId } = render(getInstance())
-		fireEvent.click(getByTestId('__vocal-root__'))
+	it('sets aria-pressed when listening', async () => {
+		// aria-pressed is gated on the real 'start' event, not the optimistic click,
+		// so drive a mock that actually fires 'start' to reach the listening state.
+		const recognition = createMockVocal()
+		const { getByTestId } = render(getInstance({ __rsInstance: recognition }))
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+		})
 		expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-pressed', 'true')
 	})
 
@@ -315,6 +322,8 @@ describe('Vocal', () => {
 			fireEvent.click(getByTestId('__vocal-root__'))
 		})
 		expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-busy', 'true')
+		// pressed is gated on the real listening state, not the optimistic start window
+		expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-pressed', 'false')
 
 		await act(async () => {
 			recognition.fire('start', new Event('start'))

--- a/src/components/__tests__/__snapshots__/Vocal.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Vocal.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Vocal > matches snapshot 1`] = `
 <DocumentFragment>
   <button
+    aria-busy="false"
     aria-label="start recognition"
     aria-pressed="false"
     data-testid="__vocal-root__"

--- a/src/hooks/__tests__/useVocal.test.ts
+++ b/src/hooks/__tests__/useVocal.test.ts
@@ -390,6 +390,56 @@ describe('useVocal', () => {
 			expect(result.current[1].isRecording).toBe(false)
 		})
 
+		it('exposes isStarting as false initially', () => {
+			const { result } = renderHook(() => useVocal())
+			expect(result.current[1].isStarting).toBe(false)
+		})
+
+		it('optimistically flips isStarting to true on start(), then clears it once the start event fires', async () => {
+			let resolveStart: (() => void) | undefined
+			mockStart.mockReturnValue(
+				new Promise<void>((res) => {
+					resolveStart = res
+				})
+			)
+			const { result } = renderHook(() => useVocal())
+			let startPromise: Promise<void> | undefined
+			await act(async () => {
+				startPromise = result.current[1].start()
+			})
+			expect(result.current[1].isStarting).toBe(true)
+			expect(result.current[1].isRecording).toBe(true)
+
+			await act(async () => {
+				mockOn.mock.calls
+					.filter(([type]) => type === 'start')
+					.forEach(([, handler]) => (handler as () => void)())
+				resolveStart?.()
+				await startPromise
+			})
+			expect(result.current[1].isStarting).toBe(false)
+			expect(result.current[1].isRecording).toBe(true)
+		})
+
+		it('clears isStarting when start() silently resolves without firing start', async () => {
+			mockStart.mockReturnValue(Promise.resolve())
+			const { result } = renderHook(() => useVocal())
+			await act(async () => {
+				await result.current[1].start()
+			})
+			expect(result.current[1].isStarting).toBe(false)
+			expect(result.current[1].isRecording).toBe(false)
+		})
+
+		it('clears isStarting when start() rejects', async () => {
+			mockStart.mockReturnValue(Promise.reject(new Error('mic denied')))
+			const { result } = renderHook(() => useVocal())
+			await act(async () => {
+				await result.current[1].start()?.catch(() => {})
+			})
+			expect(result.current[1].isStarting).toBe(false)
+		})
+
 		it('optimistically flips isRecording to true when start() is called', async () => {
 			// Simulate vocal's real contract: 'start' fires before start() resolves.
 			mockStart.mockImplementation(async () => {

--- a/src/hooks/__tests__/useVocal.test.ts
+++ b/src/hooks/__tests__/useVocal.test.ts
@@ -440,6 +440,32 @@ describe('useVocal', () => {
 			expect(result.current[1].isStarting).toBe(false)
 		})
 
+		it('clears isStarting on the end event', async () => {
+			// Keep start() pending so the optimistic flag stays true while we fire 'end'.
+			mockStart.mockReturnValue(new Promise<void>(() => {}))
+			const { result } = renderHook(() => useVocal())
+			await act(async () => {
+				result.current[1].start()
+			})
+			expect(result.current[1].isStarting).toBe(true)
+			const endCallback = mockOn.mock.calls.find(([type]) => type === 'end')![1]
+			await act(async () => endCallback(new Event('end')))
+			expect(result.current[1].isStarting).toBe(false)
+		})
+
+		it('clears isStarting on the error event', async () => {
+			// Keep start() pending so the optimistic flag stays true while we fire 'error'.
+			mockStart.mockReturnValue(new Promise<void>(() => {}))
+			const { result } = renderHook(() => useVocal())
+			await act(async () => {
+				result.current[1].start()
+			})
+			expect(result.current[1].isStarting).toBe(true)
+			const errorCallback = mockOn.mock.calls.find(([type]) => type === 'error')![1]
+			await act(async () => errorCallback(new Event('error')))
+			expect(result.current[1].isStarting).toBe(false)
+		})
+
 		it('optimistically flips isRecording to true when start() is called', async () => {
 			// Simulate vocal's real contract: 'start' fires before start() resolves.
 			mockStart.mockImplementation(async () => {

--- a/src/hooks/useVocal.ts
+++ b/src/hooks/useVocal.ts
@@ -22,6 +22,7 @@ export interface UseVocalActions {
 	}
 	clean: () => void
 	isRecording: boolean
+	isStarting: boolean
 	permissionState: PermissionState | null
 }
 
@@ -35,6 +36,7 @@ export const useVocal = (
 ): UseVocalReturn => {
 	const ref = useRef<VocalInstance | null>(null)
 	const [isRecording, setIsRecording] = useState(false)
+	const [isStarting, setIsStarting] = useState(false)
 	const [permissionState, setPermissionState] = useState<PermissionState | null>(null)
 	const supported = useMemo(() => isSupported(), [])
 
@@ -43,8 +45,14 @@ export const useVocal = (
 			const instance = createVocal({ lang, grammars, maxAlternatives, continuous })
 			ref.current = instance
 
-			const handleStart = () => setIsRecording(true)
-			const handleStop = () => setIsRecording(false)
+			const handleStart = () => {
+				setIsRecording(true)
+				setIsStarting(false)
+			}
+			const handleStop = () => {
+				setIsRecording(false)
+				setIsStarting(false)
+			}
 			instance.on('start', handleStart)
 			instance.on('end', handleStop)
 			instance.on('error', handleStop)
@@ -60,6 +68,7 @@ export const useVocal = (
 				instance.abort()
 				instance.cleanup()
 				setIsRecording(false)
+				setIsStarting(false)
 				setPermissionState(null)
 			}
 		}
@@ -71,6 +80,7 @@ export const useVocal = (
 		// Optimistic update so the UI reacts immediately at click, before the
 		// async permission/getUserMedia chain resolves and fires the 'start' event.
 		setIsRecording(true)
+		setIsStarting(true)
 		// vocal 2.x's start() can either reject (microphone/permission errors) or
 		// silently resolve without dispatching 'start' (AbortError on the signal —
 		// caught and swallowed internally, or any other no-op resolution). In both
@@ -85,9 +95,13 @@ export const useVocal = (
 		instance.on('start', onStart)
 		try {
 			await instance.start(options)
-			if (!startEventFired) setIsRecording(false)
+			if (!startEventFired) {
+				setIsRecording(false)
+				setIsStarting(false)
+			}
 		} catch (err) {
 			setIsRecording(false)
+			setIsStarting(false)
 			throw err
 		} finally {
 			instance.off('start', onStart)
@@ -130,5 +144,5 @@ export const useVocal = (
 		}
 	}, [])
 
-	return [ref, { start, stop, abort, subscribe, unsubscribe, clean, isRecording, permissionState }]
+	return [ref, { start, stop, abort, subscribe, unsubscribe, clean, isRecording, isStarting, permissionState }]
 }


### PR DESCRIPTION
## Summary
Between the click and the `start` event firing, the browser can spend several seconds resolving the `getUserMedia` microphone permission (especially on first visit). During that window the default button exposed no `aria-busy` state, so assistive-tech users got no feedback that the click was registered while the app waited for the microphone.

This adds a dedicated "starting" state, distinct from the optimistic "listening" state, and surfaces it as `aria-busy="true"` on the default button and the cloned child.

## Changes
- **`useVocal`**: new reactive `isStarting` flag — `true` for the pending window between `start()` and the real `start` event (the `getUserMedia` resolution gap), cleared on `start`/`end`/`error`, and on the silent-resolution rollback and rejection paths. Added to the hook's public return value.
- **`Vocal`**: consumes `isStarting` and applies `aria-busy={isStarting}` on the default button and injects `aria-busy` on the cloned child (parity with the existing `aria-pressed` injection).
- **Tests**: hook-level coverage for the `isStarting` lifecycle (optimistic flip, clear-on-start, clear-on-silent-resolve, clear-on-reject) and component-level coverage for `aria-busy` on both the default button and the cloned child (idle → pending → listening). Updated the idle snapshot.
- **Docs**: documented the `isStarting` flag in the `useVocal` return table and the `aria-busy` injection in the accessibility note.

## Notes
- The render-prop (function-children) signature is intentionally unchanged — the issue scopes the feedback to the default button and the cloned child.
- The optional visual cue (pulse/spinner) is deferred; consumers can build one from the now-public `isStarting` flag.
- Exposing `isStarting` on `useVocal` is purely additive (no breaking change); it is shipped under the issue's `fix(vocal)` framing.

## Test plan
- [x] `yarn test:ci` — 177 tests pass, coverage unchanged
- [x] `yarn build` — library + type declarations build (`isStarting` present in `dist/index.d.ts`)
- [x] `yarn typecheck` / `yarn lint` — clean
- [x] Demo builds against the updated source; the default button inherits `aria-busy` with no demo code change
- [ ] Manual: with a screen reader, click the default button on first visit and confirm the busy state is announced while permission resolves

Closes #225