### PR TITLE
refactor(vocal): Default button mutates outline imperatively from focus/blur handlers

### DIFF
--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -5,6 +5,7 @@ import {
 	useEffect,
 	useMemo,
 	useRef,
+	useState,
 	type CSSProperties,
 	type MouseEvent as ReactMouseEvent,
 	type ReactElement,
@@ -119,6 +120,8 @@ const tryMatchCommand = (results: Iterable<Iterable<ResultSegmentLike>>, trigger
 	}
 }
 
+export const DEFAULT_OUTLINE_STYLE = '2px solid'
+
 export const Vocal = ({
 	children,
 	commands = null,
@@ -132,7 +135,7 @@ export const Vocal = ({
 	ariaLabel = 'start recognition',
 	style = null,
 	className = null,
-	outlineStyle = '2px solid',
+	outlineStyle = DEFAULT_OUTLINE_STYLE,
 	onStart = null,
 	onEnd = null,
 	onSpeechStart = null,
@@ -143,7 +146,7 @@ export const Vocal = ({
 	onPermission = null,
 	signal = null,
 }: VocalProps) => {
-	const buttonRef = useRef<HTMLButtonElement | null>(null)
+	const [isFocused, setIsFocused] = useState(false)
 	const isSupported = useMemo(() => isSupportedFn(), [])
 
 	const [, { start, stop, subscribe, unsubscribe, isRecording: isListening, permissionState }] = useVocal(
@@ -326,22 +329,9 @@ export const Vocal = ({
 		}
 	}, [HANDLERS, subscribe, unsubscribe, start, stopSilenceTimer, _onError, signal])
 
-	const _onFocus = useCallback(() => {
-		if (!className && outlineStyle && buttonRef.current) {
-			buttonRef.current.style.outline = outlineStyle
-		}
-	}, [className, outlineStyle])
-
-	const _onBlur = useCallback(() => {
-		if (!className && outlineStyle && buttonRef.current) {
-			buttonRef.current.style.outline = 'none'
-		}
-	}, [className, outlineStyle])
-
 	const _renderDefault = () => (
 		<button
 			data-testid="__vocal-root__"
-			ref={buttonRef}
 			aria-label={ariaLabel}
 			aria-pressed={isListening}
 			style={
@@ -355,11 +345,12 @@ export const Vocal = ({
 							padding: 0,
 							cursor: 'pointer',
 							...(style ?? {}),
+							outline: isFocused && outlineStyle ? outlineStyle : 'none',
 						}
 			}
 			className={className ?? undefined}
-			onFocus={_onFocus}
-			onBlur={_onBlur}
+			onFocus={() => setIsFocused(true)}
+			onBlur={() => setIsFocused(false)}
 			onClick={isListening ? stopRecognition : startRecognition}
 		>
 			<Icon isActive={isListening} color="#aaa" />

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -3,7 +3,7 @@ import { waitFor } from '@testing-library/dom'
 import { act, fireEvent, render } from '@testing-library/react'
 import { createVocal, isSupported, type VocalInstance } from '@untemps/vocal'
 
-import { Vocal, type VocalProps } from '../Vocal'
+import { DEFAULT_OUTLINE_STYLE, Vocal, type VocalProps } from '../Vocal'
 import { createMockVocal } from './createMockVocal'
 
 vi.mock('@untemps/vocal', async (importOriginal) => {
@@ -277,16 +277,28 @@ describe('Vocal', () => {
 		expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-pressed', 'true')
 	})
 
-	it('renders outline when focused', () => {
+	it('renders the default outline when focused', () => {
 		const { getByTestId } = render(getInstance())
 		fireEvent.focus(getByTestId('__vocal-root__'))
-		expect(getByTestId('__vocal-root__')).toHaveStyle({ outline: '2px solid' })
+		expect(getByTestId('__vocal-root__')).toHaveStyle({ outline: DEFAULT_OUTLINE_STYLE })
 	})
 
 	it('remove outline when blurred', () => {
 		const { getByTestId } = render(getInstance())
 		fireEvent.blur(getByTestId('__vocal-root__'))
 		expect(getByTestId('__vocal-root__')).toHaveStyle({ outline: 'none' })
+	})
+
+	it('renders no outline before any focus', () => {
+		const { getByTestId } = render(getInstance())
+		expect(getByTestId('__vocal-root__')).toHaveStyle({ outline: 'none' })
+	})
+
+	it('applies a custom outlineStyle on focus', () => {
+		const outlineStyle = '3px dashed red'
+		const { getByTestId } = render(getInstance({ outlineStyle }))
+		fireEvent.focus(getByTestId('__vocal-root__'))
+		expect(getByTestId('__vocal-root__')).toHaveStyle({ outline: outlineStyle })
 	})
 
 	it('not uses style when className is set', () => {

--- a/src/components/__tests__/__snapshots__/Vocal.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Vocal.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Vocal > matches snapshot 1`] = `
     aria-label="start recognition"
     aria-pressed="false"
     data-testid="__vocal-root__"
-    style="width: 24px; height: 24px; background-color: transparent; border: medium; padding: 0px; cursor: pointer;"
+    style="width: 24px; height: 24px; background-color: transparent; border: medium; padding: 0px; cursor: pointer; outline: none;"
   >
     <svg
       aria-hidden="true"


### PR DESCRIPTION
## Summary
Replaces the imperative outline mutation in `Vocal`'s default button (`buttonRef.current.style.outline` set from `onFocus`/`onBlur`) with a React-managed approach: a local `isFocused` state folds the outline into the existing `style` prop. This keeps the component within React's rendering model and removes the only consumer of `buttonRef`.

## Changes
- `src/components/Vocal.tsx`:
  - Add a local `isFocused` state; `onFocus`/`onBlur` now just toggle it.
  - Fold `outline: isFocused && outlineStyle ? outlineStyle : 'none'` into the React-managed `style` object (declared last so the focus outline stays authoritative over any user-supplied `style.outline`).
  - Remove `_onFocus`/`_onBlur` `useCallback`s and the now-unused `buttonRef`.
- `src/components/__tests__/Vocal.test.tsx`: add coverage for the initial (unfocused) `outline: none` state and for a custom `outlineStyle` applied on focus. Existing focus/blur tests pass unchanged.
- Update the default-button snapshot to include `outline: none` at rest (direct, more consistent consequence of folding the outline into the inline style).

## Behavior
No public API change. The outline still appears on any focus and the `outlineStyle` prop keeps its meaning. The only observable difference: the default button now exposes `outline: none` inline at rest (previously it had no `outline` property until first focus/blur).

## Test plan
- [x] `yarn test:ci` — 171 tests pass; `Vocal.tsx` at 100% line coverage
- [x] `yarn build` — succeeds
- [x] `yarn typecheck` — clean
- [x] `yarn lint` — clean
- [x] Demo (`dev/`, default button) boots without error

Closes #226