### PR TITLE
fix: Restore single-word matching in mixed command maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,13 +253,13 @@ To do so the hook uses [fuse.js](https://fusejs.io/) which implements an algorit
 
 fuse.js is an optional peer dependency — install it separately to enable fuzzy matching (see [Installation](#installation)). Without it, phrase commands fall back to case-insensitive exact matching.
 
-**Single-word command keys** (e.g. `rouge`, `submit`) use exact case-insensitive lookup. When the recognition returns a multi-word transcript, each word is tried individually so a command fires even when embedded in a phrase (e.g. _"je veux du rouge"_ triggers `rouge`).
+**Single-word command keys** (e.g. `red`, `submit`) use exact case-insensitive lookup. When the recognition returns a multi-word transcript, each word is tried individually so a command fires even when embedded in a phrase (e.g. _"I want some red"_ triggers `red`).
 
 **Phrase command keys** (e.g. `'Change the background color'`) use [fuse.js](https://fusejs.io/) fuzzy matching. The `precision` prop controls the Fuse.js score threshold (default `0.4` — lower is stricter).
 
-**Mixing single-word and phrase keys** is fully supported — a phrase key never disables single-word matching. For each transcript the hook tries, in order: (1) an exact match of the whole utterance against a single-word key, (2) fuzzy matching against the phrase keys, then (3) each word of the utterance against the single-word keys. The first command whose callback returns a non-`null` value wins (returning `null` is treated as "no match" and falls through to the next step). So an exact phrase like _"change the background color"_ fires the phrase even when a single-word key (`color`) appears inside it, while an embedded single word like _"je veux du rouge"_ still fires `rouge` when no phrase matches.
+**Mixing single-word and phrase keys** is fully supported — a phrase key never disables single-word matching. For each transcript the hook tries, in order: (1) an exact match of the whole utterance against a single-word key, (2) fuzzy matching against the phrase keys, then (3) each word of the utterance against the single-word keys. The first command whose callback returns a non-`null` value wins (returning `null` is treated as "no match" and falls through to the next step). So an exact phrase like _"change the background color"_ fires the phrase even when a single-word key (`color`) appears inside it, while an embedded single word like _"I want some red"_ still fires `red` when no phrase matches.
 
-**Homophone tolerance** is achieved via `maxAlternatives`: by setting it to 3–5, the speech engine returns several transcription candidates per segment. The correct word (e.g. _vert_) may appear as a secondary alternative when the primary is a homophone (e.g. _verre_), and will still trigger the command.
+**Homophone tolerance** is achieved via `maxAlternatives`: by setting it to 3–5, the speech engine returns several transcription candidates per segment. The correct word (e.g. _blue_) may appear as a secondary alternative when the primary is a homophone (e.g. _blew_), and will still trigger the command.
 
 **At most one command fires per utterance.** Alternatives and segments are scanned in order and matching stops at the first hit, so a single recognition event can trigger at most one command callback.
 
@@ -274,7 +274,7 @@ fuse.js is an optional peer dependency — install it separately to enable fuzzy
 | grammars        | SpeechGrammarList | null                 | Grammars understood by the recognition [JSpeech Grammar Format](https://www.w3.org/TR/jsgf/)    |
 | timeout         | number            | 3000                 | Time in ms to wait before discarding the recognition                                            |
 | precision       | number            | 0.4                  | Fuse.js score threshold for **phrase** command keys only (lower = stricter). Single-word commands always use exact lookup. |
-| maxAlternatives | number            | 1                    | Maximum number of recognition alternatives per segment. Setting this to 3–5 lets the engine surface the correct word as a secondary transcript, which is useful for handling homophones (e.g. _vert_ / _verre_ in French). |
+| maxAlternatives | number            | 1                    | Maximum number of recognition alternatives per segment. Setting this to 3–5 lets the engine surface the correct word as a secondary transcript, which is useful for handling homophones (e.g. _blue_ / _blew_). |
 | continuous      | boolean           | false                | Keep the recognition session open after each result. The session accumulates transcript across segments and stops when the button is clicked again or `silenceTimeout` expires. Commands are not evaluated in continuous mode. |
 | silenceTimeout  | number            | null                 | When `continuous` is true, automatically stop the session after this many ms of inactivity following the last recognized result. `null` or `0` disables auto-stop (button click required). |
 | style         | object            | null                 | Styles of the root element if className is not specified                                        |
@@ -305,7 +305,7 @@ import Icon from './Icon'
 const App = () => {
 	const [result, setResult] = useState('')
 
-	const [, { start, subscribe, unsubscribe, isRecording }] = useVocal('fr-FR')
+	const [, { start, subscribe, unsubscribe, isRecording }] = useVocal('en-US')
 
 	useEffect(() => {
 		const _onVocalStart = () => {
@@ -418,12 +418,12 @@ import { useVocal, useCommands } from '@untemps/react-vocal'
 
 const App = () => {
 	const commands = {
-		rouge: () => setBorderColor('red'),
-		bleu: () => setBorderColor('blue'),
+		red: () => setBorderColor('red'),
+		blue: () => setBorderColor('blue'),
 	}
 	const triggerCommand = useCommands(commands)
 
-	const [, { start, subscribe }] = useVocal('fr-FR')
+	const [, { start, subscribe }] = useVocal('en-US')
 
 	const _onResult = (_event, bestAlternative) => {
 		triggerCommand(bestAlternative)
@@ -455,7 +455,7 @@ useCommands(commands, precision)
 
 Matching rules:
 
-- **Single-word keys** (e.g. `rouge`, `submit`): exact case-insensitive lookup, with each word of the input tried individually so a key fires even when embedded in a phrase (`je veux du rouge` triggers `rouge`).
+- **Single-word keys** (e.g. `red`, `submit`): exact case-insensitive lookup, with each word of the input tried individually so a key fires even when embedded in a phrase (`I want some red` triggers `red`).
 - **Phrase keys** (e.g. `change the background color`): Fuse.js fuzzy matching against the joined transcript, gated by `precision`. fuse.js is loaded lazily; if it's not installed, the hook falls back to substring matching.
 - **Precedence** (mixed maps): an exact single-word utterance is tried first, then phrase fuzzy matching, then single words embedded in a multi-word transcript. The first command whose callback returns a non-`null` value wins; a `null` return is treated as no-match and falls through.
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ fuse.js is an optional peer dependency — install it separately to enable fuzzy
 
 **Phrase command keys** (e.g. `'Change the background color'`) use [fuse.js](https://fusejs.io/) fuzzy matching. The `precision` prop controls the Fuse.js score threshold (default `0.4` — lower is stricter).
 
+**Mixing single-word and phrase keys** is fully supported — a phrase key never disables single-word matching. For each transcript the hook tries, in order: (1) an exact match of the whole utterance against a single-word key, (2) fuzzy matching against the phrase keys, then (3) each word of the utterance against the single-word keys. The first command whose callback returns a non-`null` value wins (returning `null` is treated as "no match" and falls through to the next step). So an exact phrase like _"change the background color"_ fires the phrase even when a single-word key (`color`) appears inside it, while an embedded single word like _"je veux du rouge"_ still fires `rouge` when no phrase matches.
+
 **Homophone tolerance** is achieved via `maxAlternatives`: by setting it to 3–5, the speech engine returns several transcription candidates per segment. The correct word (e.g. _vert_) may appear as a secondary alternative when the primary is a homophone (e.g. _verre_), and will still trigger the command.
 
 **At most one command fires per utterance.** Alternatives and segments are scanned in order and matching stops at the first hit, so a single recognition event can trigger at most one command callback.
@@ -455,6 +457,7 @@ Matching rules:
 
 - **Single-word keys** (e.g. `rouge`, `submit`): exact case-insensitive lookup, with each word of the input tried individually so a key fires even when embedded in a phrase (`je veux du rouge` triggers `rouge`).
 - **Phrase keys** (e.g. `change the background color`): Fuse.js fuzzy matching against the joined transcript, gated by `precision`. fuse.js is loaded lazily; if it's not installed, the hook falls back to substring matching.
+- **Precedence** (mixed maps): an exact single-word utterance is tried first, then phrase fuzzy matching, then single words embedded in a multi-word transcript. The first command whose callback returns a non-`null` value wins; a `null` return is treated as no-match and falls through.
 
 ### Browser support flag
 

--- a/dev/src/index.jsx
+++ b/dev/src/index.jsx
@@ -3,9 +3,6 @@ import { createRoot } from 'react-dom/client'
 
 import { Vocal } from '../../src'
 
-// Mixed command map: single-word keys (exact lookup, fire even when embedded in a phrase)
-// alongside a phrase key (fuzzy matching). See #246 — a phrase key must not disable the
-// single-word matching, so saying "I want some red" still triggers `red`.
 const COMMANDS = {
 	red: 'red',
 	blue: 'blue',

--- a/dev/src/index.jsx
+++ b/dev/src/index.jsx
@@ -3,11 +3,15 @@ import { createRoot } from 'react-dom/client'
 
 import { Vocal } from '../../src'
 
+// Mixed command map: single-word keys (exact lookup, fire even when embedded in a phrase)
+// alongside a phrase key (fuzzy matching). See #246 — a phrase key must not disable the
+// single-word matching, so saying "je veux du rouge" still triggers `rouge`.
 const COMMANDS = {
 	rouge: 'red',
 	bleu: 'blue',
 	vert: 'green',
 	jaune: 'yellow',
+	'change la bordure en orange': 'orange',
 }
 
 const App = () => {
@@ -52,18 +56,22 @@ const App = () => {
 			<p style={{ fontSize: 12, color: '#666', margin: '8px 0' }}>
 				Permission micro : <code>{permission ?? 'inconnue'}</code>
 			</p>
-            <p style={{ fontSize: 12, color: '#666', margin: '8px 0' }}>
-              <label style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                <input type="checkbox" checked={continuous} onChange={(e) => setContinuous(e.target.checked)} />
-                Mode continu
-              </label>
-            </p>
+			<p style={{ fontSize: 12, color: '#666', margin: '8px 0' }}>
+				<label style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+					<input type="checkbox" checked={continuous} onChange={(e) => setContinuous(e.target.checked)} />
+					Mode continu
+				</label>
+			</p>
 			<p style={{ fontSize: 12, color: '#666', margin: '8px 0' }}>
 				Commandes :{' '}
 				{Object.keys(COMMANDS).map((k, i) => (
-					<span key={k}>{i > 0 && ', '}<code>{k}</code></span>
-				))}
-				{' '}— ou dans une phrase (ex : «&nbsp;je veux du vert&nbsp;»)
+					<span key={k}>
+						{i > 0 && ', '}
+						<code>{k}</code>
+					</span>
+				))}{' '}
+				— les mots simples se déclenchent même dans une phrase (ex : «&nbsp;je veux du rouge&nbsp;»), la
+				commande phrase tolère les approximations
 			</p>
 			<textarea value={logs} rows={30} disabled style={{ width: '100%', borderColor }} />
 		</>

--- a/dev/src/index.jsx
+++ b/dev/src/index.jsx
@@ -5,13 +5,13 @@ import { Vocal } from '../../src'
 
 // Mixed command map: single-word keys (exact lookup, fire even when embedded in a phrase)
 // alongside a phrase key (fuzzy matching). See #246 — a phrase key must not disable the
-// single-word matching, so saying "je veux du rouge" still triggers `rouge`.
+// single-word matching, so saying "I want some red" still triggers `red`.
 const COMMANDS = {
-	rouge: 'red',
-	bleu: 'blue',
-	vert: 'green',
-	jaune: 'yellow',
-	'change la bordure en orange': 'orange',
+	red: 'red',
+	blue: 'blue',
+	green: 'green',
+	yellow: 'yellow',
+	'change the border to orange': 'orange',
 }
 
 const App = () => {
@@ -40,7 +40,7 @@ const App = () => {
 	return (
 		<>
 			<Vocal
-				lang="fr"
+				lang="en-US"
 				commands={commands}
 				continuous={continuous}
 				onStart={() => _log('start')}
@@ -54,24 +54,24 @@ const App = () => {
 				maxAlternatives={3}
 			/>
 			<p style={{ fontSize: 12, color: '#666', margin: '8px 0' }}>
-				Permission micro : <code>{permission ?? 'inconnue'}</code>
+				Microphone permission: <code>{permission ?? 'unknown'}</code>
 			</p>
 			<p style={{ fontSize: 12, color: '#666', margin: '8px 0' }}>
 				<label style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
 					<input type="checkbox" checked={continuous} onChange={(e) => setContinuous(e.target.checked)} />
-					Mode continu
+					Continuous mode
 				</label>
 			</p>
 			<p style={{ fontSize: 12, color: '#666', margin: '8px 0' }}>
-				Commandes :{' '}
+				Commands:{' '}
 				{Object.keys(COMMANDS).map((k, i) => (
 					<span key={k}>
 						{i > 0 && ', '}
 						<code>{k}</code>
 					</span>
 				))}{' '}
-				— les mots simples se déclenchent même dans une phrase (ex : «&nbsp;je veux du rouge&nbsp;»), la
-				commande phrase tolère les approximations
+				— single words fire even inside a sentence (e.g. “I want some red”), and the phrase command tolerates
+				approximations
 			</p>
 			<textarea value={logs} rows={30} disabled style={{ width: '100%', borderColor }} />
 		</>

--- a/src/hooks/__tests__/useCommands.test.ts
+++ b/src/hooks/__tests__/useCommands.test.ts
@@ -131,8 +131,6 @@ describe('useCommands', () => {
 	})
 
 	describe('Mixed command map', () => {
-		// Primary regression anchor for #246: with a phrase key present, an embedded single
-		// word must still fire. This is the one input that returns null on the pre-fix code.
 		it('fires a single-word command embedded in a phrase even when a phrase key also exists', async () => {
 			const rouge = vi.fn(() => 'red')
 			const commands = {
@@ -142,14 +140,11 @@ describe('useCommands', () => {
 			const {
 				result: { current: triggerCommand },
 			} = renderHook(() => useCommands(commands))
-			// Flush the dynamic fuse.js import microtask so the phrase path is fully wired.
 			await act(async () => {})
 			expect(triggerCommand('je veux du rouge')).toBe('red')
 			expect(rouge).toHaveBeenCalledWith('rouge', 'rouge')
 		})
 
-		// An exact/near-exact phrase utterance must win over a single-word key that merely
-		// appears inside the phrase — otherwise the embedded word would hijack the phrase.
 		it('prefers the phrase command over an embedded single-word key for an exact-phrase utterance', async () => {
 			const color = vi.fn(() => 'single')
 			const phrase = vi.fn(() => 'phrase')
@@ -166,8 +161,6 @@ describe('useCommands', () => {
 			expect(color).not.toHaveBeenCalled()
 		})
 
-		// The reverse priority: a deliberate one-word utterance must still fire its single-word
-		// command even when that word also appears inside a phrase key.
 		it('prefers the exact single-word command over a phrase key that contains the word', async () => {
 			const phrase = vi.fn(() => 'phrase')
 			const commands = {
@@ -182,8 +175,6 @@ describe('useCommands', () => {
 			expect(phrase).not.toHaveBeenCalled()
 		})
 
-		// A single-word callback returning null (the "no match" sentinel) must not suppress a
-		// phrase command that matches the same utterance.
 		it('falls through to the phrase command when a single-word callback returns null', async () => {
 			const commands = {
 				color: () => null,
@@ -196,8 +187,6 @@ describe('useCommands', () => {
 			expect(triggerCommand('change the background color')).toBe('changed')
 		})
 
-		// null fall-through within the per-word pass: a declined single-word command must not
-		// block another single-word command spoken in the same utterance.
 		it('keeps scanning words when a single-word callback returns null', async () => {
 			const commands = {
 				rouge: () => null,
@@ -220,7 +209,6 @@ describe('useCommands', () => {
 			} = renderHook(() => useCommands(commands))
 			await act(async () => {})
 			expect(triggerCommand('change the background color')).toBe('changed')
-			// Fuzzy tolerance still applies to the phrase key.
 			expect(triggerCommand('change the background colour')).toBe('changed')
 		})
 

--- a/src/hooks/__tests__/useCommands.test.ts
+++ b/src/hooks/__tests__/useCommands.test.ts
@@ -130,6 +130,125 @@ describe('useCommands', () => {
 		expect(triggerCommand('vert')).toBe('green')
 	})
 
+	describe('Mixed command map', () => {
+		// Primary regression anchor for #246: with a phrase key present, an embedded single
+		// word must still fire. This is the one input that returns null on the pre-fix code.
+		it('fires a single-word command embedded in a phrase even when a phrase key also exists', async () => {
+			const rouge = vi.fn(() => 'red')
+			const commands = {
+				rouge,
+				'change the background color': () => 'changed',
+			}
+			const {
+				result: { current: triggerCommand },
+			} = renderHook(() => useCommands(commands))
+			// Flush the dynamic fuse.js import microtask so the phrase path is fully wired.
+			await act(async () => {})
+			expect(triggerCommand('je veux du rouge')).toBe('red')
+			expect(rouge).toHaveBeenCalledWith('rouge', 'rouge')
+		})
+
+		// An exact/near-exact phrase utterance must win over a single-word key that merely
+		// appears inside the phrase — otherwise the embedded word would hijack the phrase.
+		it('prefers the phrase command over an embedded single-word key for an exact-phrase utterance', async () => {
+			const color = vi.fn(() => 'single')
+			const phrase = vi.fn(() => 'phrase')
+			const commands = {
+				color,
+				'change the background color': phrase,
+			}
+			const {
+				result: { current: triggerCommand },
+			} = renderHook(() => useCommands(commands))
+			await act(async () => {})
+			expect(triggerCommand('change the background color')).toBe('phrase')
+			expect(phrase).toHaveBeenCalled()
+			expect(color).not.toHaveBeenCalled()
+		})
+
+		// The reverse priority: a deliberate one-word utterance must still fire its single-word
+		// command even when that word also appears inside a phrase key.
+		it('prefers the exact single-word command over a phrase key that contains the word', async () => {
+			const phrase = vi.fn(() => 'phrase')
+			const commands = {
+				rouge: () => 'red',
+				'change la bordure en rouge': phrase,
+			}
+			const {
+				result: { current: triggerCommand },
+			} = renderHook(() => useCommands(commands))
+			await act(async () => {})
+			expect(triggerCommand('rouge')).toBe('red')
+			expect(phrase).not.toHaveBeenCalled()
+		})
+
+		// A single-word callback returning null (the "no match" sentinel) must not suppress a
+		// phrase command that matches the same utterance.
+		it('falls through to the phrase command when a single-word callback returns null', async () => {
+			const commands = {
+				color: () => null,
+				'change the background color': () => 'changed',
+			}
+			const {
+				result: { current: triggerCommand },
+			} = renderHook(() => useCommands(commands))
+			await act(async () => {})
+			expect(triggerCommand('change the background color')).toBe('changed')
+		})
+
+		// null fall-through within the per-word pass: a declined single-word command must not
+		// block another single-word command spoken in the same utterance.
+		it('keeps scanning words when a single-word callback returns null', async () => {
+			const commands = {
+				rouge: () => null,
+				bleu: () => 'blue',
+			}
+			const {
+				result: { current: triggerCommand },
+			} = renderHook(() => useCommands(commands))
+			await act(async () => {})
+			expect(triggerCommand('rouge ou bleu')).toBe('blue')
+		})
+
+		it('still fires the phrase command via fuzzy matching in a mixed map', async () => {
+			const commands = {
+				rouge: () => 'red',
+				'change the background color': () => 'changed',
+			}
+			const {
+				result: { current: triggerCommand },
+			} = renderHook(() => useCommands(commands))
+			await act(async () => {})
+			expect(triggerCommand('change the background color')).toBe('changed')
+			// Fuzzy tolerance still applies to the phrase key.
+			expect(triggerCommand('change the background colour')).toBe('changed')
+		})
+
+		it('matches a single-word command exactly in a mixed map', async () => {
+			const commands = {
+				rouge: () => 'red',
+				'change the background color': () => 'changed',
+			}
+			const {
+				result: { current: triggerCommand },
+			} = renderHook(() => useCommands(commands))
+			await act(async () => {})
+			expect(triggerCommand('rouge')).toBe('red')
+		})
+
+		it('returns null in a mixed map when no command matches', async () => {
+			const commands = {
+				rouge: () => 'red',
+				'change the background color': () => 'changed',
+			}
+			const {
+				result: { current: triggerCommand },
+			} = renderHook(() => useCommands(commands))
+			await act(async () => {})
+			expect(triggerCommand('je veux du bleu')).toBeNull()
+		})
+	})
+
 	it('falls back to contains matching when fuse.js is not available', async () => {
 		vi.doMock('fuse.js', () => {
 			throw new Error('fuse.js not installed')
@@ -141,6 +260,25 @@ describe('useCommands', () => {
 		} = renderHook(() => useCommandsWithoutFuse(commands))
 		await act(async () => {})
 		expect(triggerCommand('change color')).toBe('matched')
+		vi.doUnmock('fuse.js')
+	})
+
+	it('fires an embedded single-word command in a mixed map even when fuse.js is absent', async () => {
+		vi.doMock('fuse.js', () => {
+			throw new Error('fuse.js not installed')
+		})
+		const { useCommands: useCommandsWithoutFuse } = await import('../useCommands')
+		const rouge = vi.fn(() => 'red')
+		const commands = {
+			rouge,
+			'change the background color': () => 'changed',
+		}
+		const {
+			result: { current: triggerCommand },
+		} = renderHook(() => useCommandsWithoutFuse(commands))
+		await act(async () => {})
+		expect(triggerCommand('je veux du rouge')).toBe('red')
+		expect(rouge).toHaveBeenCalledWith('rouge', 'rouge')
 		vi.doUnmock('fuse.js')
 	})
 

--- a/src/hooks/__tests__/useCommands.test.ts
+++ b/src/hooks/__tests__/useCommands.test.ts
@@ -132,17 +132,17 @@ describe('useCommands', () => {
 
 	describe('Mixed command map', () => {
 		it('fires a single-word command embedded in a phrase even when a phrase key also exists', async () => {
-			const rouge = vi.fn(() => 'red')
+			const red = vi.fn(() => 'red')
 			const commands = {
-				rouge,
+				red,
 				'change the background color': () => 'changed',
 			}
 			const {
 				result: { current: triggerCommand },
 			} = renderHook(() => useCommands(commands))
 			await act(async () => {})
-			expect(triggerCommand('je veux du rouge')).toBe('red')
-			expect(rouge).toHaveBeenCalledWith('rouge', 'rouge')
+			expect(triggerCommand('I want some red')).toBe('red')
+			expect(red).toHaveBeenCalledWith('red', 'red')
 		})
 
 		it('prefers the phrase command over an embedded single-word key for an exact-phrase utterance', async () => {
@@ -164,14 +164,14 @@ describe('useCommands', () => {
 		it('prefers the exact single-word command over a phrase key that contains the word', async () => {
 			const phrase = vi.fn(() => 'phrase')
 			const commands = {
-				rouge: () => 'red',
-				'change la bordure en rouge': phrase,
+				red: () => 'red',
+				'change the border to red': phrase,
 			}
 			const {
 				result: { current: triggerCommand },
 			} = renderHook(() => useCommands(commands))
 			await act(async () => {})
-			expect(triggerCommand('rouge')).toBe('red')
+			expect(triggerCommand('red')).toBe('red')
 			expect(phrase).not.toHaveBeenCalled()
 		})
 
@@ -189,19 +189,19 @@ describe('useCommands', () => {
 
 		it('keeps scanning words when a single-word callback returns null', async () => {
 			const commands = {
-				rouge: () => null,
-				bleu: () => 'blue',
+				red: () => null,
+				blue: () => 'blue',
 			}
 			const {
 				result: { current: triggerCommand },
 			} = renderHook(() => useCommands(commands))
 			await act(async () => {})
-			expect(triggerCommand('rouge ou bleu')).toBe('blue')
+			expect(triggerCommand('red or blue')).toBe('blue')
 		})
 
 		it('still fires the phrase command via fuzzy matching in a mixed map', async () => {
 			const commands = {
-				rouge: () => 'red',
+				red: () => 'red',
 				'change the background color': () => 'changed',
 			}
 			const {
@@ -214,26 +214,26 @@ describe('useCommands', () => {
 
 		it('matches a single-word command exactly in a mixed map', async () => {
 			const commands = {
-				rouge: () => 'red',
+				red: () => 'red',
 				'change the background color': () => 'changed',
 			}
 			const {
 				result: { current: triggerCommand },
 			} = renderHook(() => useCommands(commands))
 			await act(async () => {})
-			expect(triggerCommand('rouge')).toBe('red')
+			expect(triggerCommand('red')).toBe('red')
 		})
 
 		it('returns null in a mixed map when no command matches', async () => {
 			const commands = {
-				rouge: () => 'red',
+				red: () => 'red',
 				'change the background color': () => 'changed',
 			}
 			const {
 				result: { current: triggerCommand },
 			} = renderHook(() => useCommands(commands))
 			await act(async () => {})
-			expect(triggerCommand('je veux du bleu')).toBeNull()
+			expect(triggerCommand('I want some blue')).toBeNull()
 		})
 	})
 
@@ -256,17 +256,17 @@ describe('useCommands', () => {
 			throw new Error('fuse.js not installed')
 		})
 		const { useCommands: useCommandsWithoutFuse } = await import('../useCommands')
-		const rouge = vi.fn(() => 'red')
+		const red = vi.fn(() => 'red')
 		const commands = {
-			rouge,
+			red,
 			'change the background color': () => 'changed',
 		}
 		const {
 			result: { current: triggerCommand },
 		} = renderHook(() => useCommandsWithoutFuse(commands))
 		await act(async () => {})
-		expect(triggerCommand('je veux du rouge')).toBe('red')
-		expect(rouge).toHaveBeenCalledWith('rouge', 'rouge')
+		expect(triggerCommand('I want some red')).toBe('red')
+		expect(red).toHaveBeenCalledWith('red', 'red')
 		vi.doUnmock('fuse.js')
 	})
 

--- a/src/hooks/__tests__/useCommands.test.ts
+++ b/src/hooks/__tests__/useCommands.test.ts
@@ -130,6 +130,18 @@ describe('useCommands', () => {
 		expect(triggerCommand('vert')).toBe('green')
 	})
 
+	it('matches an embedded single-word command when words are separated by non-space whitespace', () => {
+		const red = vi.fn(() => 'red')
+		const commands = { red, blue: () => 'blue' }
+		const {
+			result: { current: triggerCommand },
+		} = renderHook(() => useCommands(commands))
+		// Recognition may join segments with tabs/newlines, not only spaces; each word is still scanned.
+		expect(triggerCommand('red\tblue')).toBe('red')
+		expect(triggerCommand('please\nred')).toBe('red')
+		expect(red).toHaveBeenCalledWith('red', 'red')
+	})
+
 	describe('Mixed command map', () => {
 		it('fires a single-word command embedded in a phrase even when a phrase key also exists', async () => {
 			const red = vi.fn(() => 'red')

--- a/src/hooks/__tests__/useCommands.test.ts
+++ b/src/hooks/__tests__/useCommands.test.ts
@@ -136,7 +136,6 @@ describe('useCommands', () => {
 		const {
 			result: { current: triggerCommand },
 		} = renderHook(() => useCommands(commands))
-		// Recognition may join segments with tabs/newlines, not only spaces; each word is still scanned.
 		expect(triggerCommand('red\tblue')).toBe('red')
 		expect(triggerCommand('please\nred')).toBe('red')
 		expect(red).toHaveBeenCalledWith('red', 'red')
@@ -255,8 +254,6 @@ describe('useCommands', () => {
 			const {
 				result: { current: triggerCommand },
 			} = renderHook(() => useCommands(commands))
-			// `'constructor' in normalized` is true via the prototype chain; Object.hasOwn
-			// keeps it from invoking the inherited Object constructor as if it were a command.
 			expect(triggerCommand('constructor')).toBeNull()
 		})
 
@@ -265,8 +262,6 @@ describe('useCommands', () => {
 			const {
 				result: { current: triggerCommand },
 			} = renderHook(() => useCommands(commands))
-			// `normalized['__proto__']` is Object.prototype (not callable) — `in` would
-			// have reached it and thrown "is not a function".
 			expect(() => triggerCommand('__proto__')).not.toThrow()
 			expect(triggerCommand('__proto__')).toBeNull()
 		})
@@ -284,16 +279,11 @@ describe('useCommands', () => {
 			const {
 				result: { current: triggerCommand },
 			} = renderHook(() => useCommands(commands))
-			// An own property named 'constructor' is a legitimate command and must still fire.
 			expect(triggerCommand('constructor')).toBe('ctor')
 		})
 	})
 
 	describe('Fuse-absent fallback (fuse.js not installed)', () => {
-		// Fresh module graph per test so `vi.doMock('fuse.js')` actually intercepts the
-		// hook's lazy `import('fuse.js')`; `doUnmock` + reset afterwards so the throwing
-		// module can never leak into a later fuzzy-matching test. (`restoreMocks` resets
-		// spy state but neither clears the module cache nor removes `doMock` registrations.)
 		beforeEach(() => {
 			vi.resetModules()
 		})
@@ -309,11 +299,7 @@ describe('useCommands', () => {
 			})
 			const { useCommands: useCommandsWithoutFuse } = await import('../useCommands')
 			const view = renderHook(() => useCommandsWithoutFuse(commands))
-			// Flush the rejected dynamic import so fuseRef settles to null.
 			await act(async () => {})
-			// Sentinel: the hook warns *only* when import('fuse.js') rejects. Asserting it
-			// fired proves fuse.js is genuinely absent here — not merely "real fuse not loaded
-			// yet", which would also leave fuseRef null and silently pass the fallback paths.
 			await vi.waitFor(() => expect(warnSpy).toHaveBeenCalled())
 			warnSpy.mockRestore()
 			return view
@@ -331,17 +317,11 @@ describe('useCommands', () => {
 			const {
 				result: { current: triggerCommand },
 			} = await renderWithoutFuse({ 'change color': phrase })
-			// Real fuse scores 'please change color now' vs 'change color' at ~0.59 > the
-			// 0.4 threshold, so a match here can come *only* from the substring fallback —
-			// combined with the warn sentinel above, this exercises the fuse-absent path.
 			expect(triggerCommand('please change color now')).toBe('changed')
 			expect(phrase).toHaveBeenCalledWith('please change color now', 'change color')
 		})
 
 		it('matches a short utterance contained in a phrase key (k.includes(lInput) — documented tradeoff)', async () => {
-			// The source flags this as an accepted false positive of the fuse-absent
-			// fallback: a single word that is a substring of a phrase key still fires it.
-			// Pinned so a regression dropping the `|| k.includes(lInput)` clause is caught.
 			const phrase = vi.fn(() => 'changed')
 			const {
 				result: { current: triggerCommand },
@@ -351,8 +331,6 @@ describe('useCommands', () => {
 		})
 
 		it('does not fire a phrase command on an empty or whitespace-only transcript', async () => {
-			// Regression for the `trimmed` guard: `k.includes('')` is always true, so an
-			// empty transcript would otherwise spuriously fire the first phrase command.
 			const phrase = vi.fn(() => 'changed')
 			const {
 				result: { current: triggerCommand },
@@ -363,8 +341,6 @@ describe('useCommands', () => {
 		})
 
 		it('keeps single-word embedded matching working in a mixed map', async () => {
-			// A phrase key + missing fuse.js must not break single-word matching:
-			// 'I want some red' resolves via the per-word scan (step 3), not fuse.
 			const red = vi.fn(() => 'red')
 			const {
 				result: { current: triggerCommand },

--- a/src/hooks/__tests__/useCommands.test.ts
+++ b/src/hooks/__tests__/useCommands.test.ts
@@ -237,54 +237,144 @@ describe('useCommands', () => {
 		})
 	})
 
-	it('falls back to contains matching when fuse.js is not available', async () => {
-		vi.doMock('fuse.js', () => {
-			throw new Error('fuse.js not installed')
+	describe('Object-prototype key safety', () => {
+		it('does not treat an inherited Object.prototype name as a registered command', () => {
+			const commands = { red: () => 'red' }
+			const {
+				result: { current: triggerCommand },
+			} = renderHook(() => useCommands(commands))
+			// `'constructor' in normalized` is true via the prototype chain; Object.hasOwn
+			// keeps it from invoking the inherited Object constructor as if it were a command.
+			expect(triggerCommand('constructor')).toBeNull()
 		})
-		const { useCommands: useCommandsWithoutFuse } = await import('../useCommands')
-		const commands = { 'change color': () => 'matched' }
-		const {
-			result: { current: triggerCommand },
-		} = renderHook(() => useCommandsWithoutFuse(commands))
-		await act(async () => {})
-		expect(triggerCommand('change color')).toBe('matched')
-		vi.doUnmock('fuse.js')
+
+		it('does not throw when the input matches the inherited "__proto__" key', () => {
+			const commands = { red: () => 'red' }
+			const {
+				result: { current: triggerCommand },
+			} = renderHook(() => useCommands(commands))
+			// `normalized['__proto__']` is Object.prototype (not callable) — `in` would
+			// have reached it and thrown "is not a function".
+			expect(() => triggerCommand('__proto__')).not.toThrow()
+			expect(triggerCommand('__proto__')).toBeNull()
+		})
+
+		it('ignores an embedded prototype name when scanning the words of a phrase', () => {
+			const commands = { red: () => 'red' }
+			const {
+				result: { current: triggerCommand },
+			} = renderHook(() => useCommands(commands))
+			expect(triggerCommand('the constructor pattern')).toBeNull()
+		})
+
+		it('still matches a command explicitly keyed with a prototype name', () => {
+			const commands = { constructor: () => 'ctor' }
+			const {
+				result: { current: triggerCommand },
+			} = renderHook(() => useCommands(commands))
+			// An own property named 'constructor' is a legitimate command and must still fire.
+			expect(triggerCommand('constructor')).toBe('ctor')
+		})
 	})
 
-	it('fires an embedded single-word command in a mixed map even when fuse.js is absent', async () => {
-		vi.doMock('fuse.js', () => {
-			throw new Error('fuse.js not installed')
+	describe('Fuse-absent fallback (fuse.js not installed)', () => {
+		// Fresh module graph per test so `vi.doMock('fuse.js')` actually intercepts the
+		// hook's lazy `import('fuse.js')`; `doUnmock` + reset afterwards so the throwing
+		// module can never leak into a later fuzzy-matching test. (`restoreMocks` resets
+		// spy state but neither clears the module cache nor removes `doMock` registrations.)
+		beforeEach(() => {
+			vi.resetModules()
 		})
-		const { useCommands: useCommandsWithoutFuse } = await import('../useCommands')
-		const red = vi.fn(() => 'red')
-		const commands = {
-			red,
-			'change the background color': () => 'changed',
+		afterEach(() => {
+			vi.doUnmock('fuse.js')
+			vi.resetModules()
+		})
+
+		const renderWithoutFuse = async (commands: Parameters<typeof useCommands>[0]) => {
+			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+			vi.doMock('fuse.js', () => {
+				throw new Error('fuse.js not installed')
+			})
+			const { useCommands: useCommandsWithoutFuse } = await import('../useCommands')
+			const view = renderHook(() => useCommandsWithoutFuse(commands))
+			// Flush the rejected dynamic import so fuseRef settles to null.
+			await act(async () => {})
+			// Sentinel: the hook warns *only* when import('fuse.js') rejects. Asserting it
+			// fired proves fuse.js is genuinely absent here — not merely "real fuse not loaded
+			// yet", which would also leave fuseRef null and silently pass the fallback paths.
+			await vi.waitFor(() => expect(warnSpy).toHaveBeenCalled())
+			warnSpy.mockRestore()
+			return view
 		}
-		const {
-			result: { current: triggerCommand },
-		} = renderHook(() => useCommandsWithoutFuse(commands))
-		await act(async () => {})
-		expect(triggerCommand('I want some red')).toBe('red')
-		expect(red).toHaveBeenCalledWith('red', 'red')
-		vi.doUnmock('fuse.js')
-	})
 
-	it('discards the dynamic fuse.js import result when the effect is cleaned up before it resolves', async () => {
-		// Without the cancellation guard, the .catch() branch would fire console.warn
-		// even after the component unmounted (stale effect). With the guard, the
-		// cleanup runs before the import settles and the .catch() is skipped.
-		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-		vi.doMock('fuse.js', () => {
-			throw new Error('fuse.js not installed')
+		it('falls back to contains matching for an exact phrase', async () => {
+			const {
+				result: { current: triggerCommand },
+			} = await renderWithoutFuse({ 'change color': () => 'matched' })
+			expect(triggerCommand('change color')).toBe('matched')
 		})
-		const { useCommands: useCommandsFresh } = await import('../useCommands')
-		const commands = { 'change color': () => 'matched' }
-		const { unmount } = renderHook(() => useCommandsFresh(commands))
-		unmount()
-		await act(async () => {})
-		expect(warnSpy).not.toHaveBeenCalled()
-		warnSpy.mockRestore()
-		vi.doUnmock('fuse.js')
+
+		it('matches a phrase key embedded in a longer utterance (lInput.includes(k))', async () => {
+			const phrase = vi.fn(() => 'changed')
+			const {
+				result: { current: triggerCommand },
+			} = await renderWithoutFuse({ 'change color': phrase })
+			// Real fuse scores 'please change color now' vs 'change color' at ~0.59 > the
+			// 0.4 threshold, so a match here can come *only* from the substring fallback —
+			// combined with the warn sentinel above, this exercises the fuse-absent path.
+			expect(triggerCommand('please change color now')).toBe('changed')
+			expect(phrase).toHaveBeenCalledWith('please change color now', 'change color')
+		})
+
+		it('matches a short utterance contained in a phrase key (k.includes(lInput) — documented tradeoff)', async () => {
+			// The source flags this as an accepted false positive of the fuse-absent
+			// fallback: a single word that is a substring of a phrase key still fires it.
+			// Pinned so a regression dropping the `|| k.includes(lInput)` clause is caught.
+			const phrase = vi.fn(() => 'changed')
+			const {
+				result: { current: triggerCommand },
+			} = await renderWithoutFuse({ 'change the border to red': phrase })
+			expect(triggerCommand('red')).toBe('changed')
+			expect(phrase).toHaveBeenCalledWith('red', 'change the border to red')
+		})
+
+		it('does not fire a phrase command on an empty or whitespace-only transcript', async () => {
+			// Regression for the `trimmed` guard: `k.includes('')` is always true, so an
+			// empty transcript would otherwise spuriously fire the first phrase command.
+			const phrase = vi.fn(() => 'changed')
+			const {
+				result: { current: triggerCommand },
+			} = await renderWithoutFuse({ 'change the background color': phrase })
+			expect(triggerCommand('')).toBeNull()
+			expect(triggerCommand('   ')).toBeNull()
+			expect(phrase).not.toHaveBeenCalled()
+		})
+
+		it('keeps single-word embedded matching working in a mixed map', async () => {
+			// A phrase key + missing fuse.js must not break single-word matching:
+			// 'I want some red' resolves via the per-word scan (step 3), not fuse.
+			const red = vi.fn(() => 'red')
+			const {
+				result: { current: triggerCommand },
+			} = await renderWithoutFuse({ red, 'change the background color': () => 'changed' })
+			expect(triggerCommand('I want some red')).toBe('red')
+			expect(red).toHaveBeenCalledWith('red', 'red')
+		})
+
+		it('discards the dynamic fuse.js import result when the effect is cleaned up before it resolves', async () => {
+			// Without the cancellation guard, the .catch() branch would fire console.warn
+			// even after the component unmounted (stale effect). With the guard, the
+			// cleanup runs before the import settles and the .catch() is skipped.
+			const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+			vi.doMock('fuse.js', () => {
+				throw new Error('fuse.js not installed')
+			})
+			const { useCommands: useCommandsFresh } = await import('../useCommands')
+			const { unmount } = renderHook(() => useCommandsFresh({ 'change color': () => 'matched' }))
+			unmount()
+			await act(async () => {})
+			expect(warnSpy).not.toHaveBeenCalled()
+			warnSpy.mockRestore()
+		})
 	})
 })

--- a/src/hooks/useCommands.ts
+++ b/src/hooks/useCommands.ts
@@ -60,8 +60,6 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 			const trimmed = rawInput.trim()
 			const isMultiWord = /\s/.test(trimmed)
 
-			// Returns null when `word` is not a registered single-word key, so the caller
-			// falls through to the next tier (a null callback result is also "no match").
 			const matchSingleWord = (word: string) => {
 				const commandKey = word.toLowerCase()
 				return Object.hasOwn(normalized, commandKey) ? normalized[commandKey]?.(word, commandKey) : null
@@ -85,8 +83,6 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 					// `k.includes(lInput)` can produce false positives when input is short
 					// (e.g. "rouge" matches "change en rouge"). Accepted tradeoff: this branch
 					// only runs when fuse.js is absent, so degraded precision is expected.
-					// The `trimmed` guard keeps an empty/whitespace-only transcript from matching
-					// every phrase key via `k.includes('')`.
 					const lInput = trimmed.toLowerCase()
 					const commandKey = phraseKeys.find((k) => lInput.includes(k) || k.includes(lInput))
 					if (commandKey) {

--- a/src/hooks/useCommands.ts
+++ b/src/hooks/useCommands.ts
@@ -61,7 +61,7 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 
 			if (singleWordKeys.length && !trimmed.includes(' ')) {
 				const commandKey = trimmed.toLowerCase()
-				if (commandKey in normalized) {
+				if (Object.hasOwn(normalized, commandKey)) {
 					const result = normalized[commandKey]?.(trimmed, commandKey)
 					if (result !== null) return result
 				}
@@ -76,11 +76,13 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 						const result = normalized[commandKey]?.(rawInput, commandKey)
 						if (result !== null) return result
 					}
-				} else {
+				} else if (trimmed) {
 					// `k.includes(lInput)` can produce false positives when input is short
 					// (e.g. "rouge" matches "change en rouge"). Accepted tradeoff: this branch
 					// only runs when fuse.js is absent, so degraded precision is expected.
-					const lInput = rawInput.toLowerCase()
+					// The `trimmed` guard keeps an empty/whitespace-only transcript from matching
+					// every phrase key via `k.includes('')`.
+					const lInput = trimmed.toLowerCase()
 					const commandKey = phraseKeys.find((k) => lInput.includes(k) || k.includes(lInput))
 					if (commandKey) {
 						const result = normalized[commandKey]?.(rawInput, commandKey)
@@ -92,7 +94,7 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 			if (singleWordKeys.length && trimmed.includes(' ')) {
 				for (const w of trimmed.split(/\s+/)) {
 					const commandKey = w.toLowerCase()
-					if (commandKey in normalized) {
+					if (Object.hasOwn(normalized, commandKey)) {
 						const result = normalized[commandKey]?.(w, commandKey)
 						if (result !== null) return result
 					}

--- a/src/hooks/useCommands.ts
+++ b/src/hooks/useCommands.ts
@@ -18,10 +18,6 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 
 	const keys = useMemo(() => Object.keys(normalized), [normalized])
 
-	// Partition keys by matching strategy. Single-word keys use exact case-insensitive
-	// lookup (simpler, no false positives); phrase keys use fuzzy matching. The two passes
-	// are independent so a mixed map keeps single-word matching working regardless of how
-	// many phrase keys it also contains.
 	const singleWordKeys = useMemo(() => keys.filter((k) => !k.includes(' ')), [keys])
 	const phraseKeys = useMemo(() => keys.filter((k) => k.includes(' ')), [keys])
 
@@ -41,9 +37,6 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 			.then((module) => {
 				if (cancelled) return
 				const FuseCtor = (module.default ?? module) as unknown as typeof Fuse
-				// Index only phrase keys: single-word keys are handled by exact lookup, so
-				// indexing them here would let a typo'd single word fuzzy-match a key that
-				// is contractually exact-only.
 				fuseRef.current = new FuseCtor(phraseKeys, { includeScore: true, ignoreLocation: true })
 			})
 			.catch(() => {
@@ -66,14 +59,6 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 
 			const trimmed = rawInput.trim()
 
-			// Three passes run in priority order; each returns the first command whose callback
-			// yields a non-null result. `null` is the documented "no match" sentinel (see
-			// tryMatchCommand in Vocal.tsx), so a callback that returns it falls through to the
-			// next pass instead of ending the scan.
-
-			// 1. Exact single-word command for the whole utterance. Highest priority so an
-			// intentional one-word command fires even when that word also appears inside a phrase
-			// key (e.g. "rouge" with a { rouge, 'change la bordure en rouge' } map).
 			if (singleWordKeys.length && !trimmed.includes(' ')) {
 				const commandKey = trimmed.toLowerCase()
 				if (commandKey in normalized) {
@@ -82,10 +67,6 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 				}
 			}
 
-			// 2. Phrase keys via fuzzy matching (or substring fallback when fuse.js is absent).
-			// Runs before the per-word pass so an exact/near-exact phrase wins over a single-word
-			// key that merely appears inside it (#246: "change the background color" must fire the
-			// phrase, not the embedded "color").
 			if (phraseKeys.length) {
 				const fuse = fuseRef.current
 				if (fuse) {
@@ -108,12 +89,9 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 				}
 			}
 
-			// 3. A single-word command embedded in a multi-word utterance ("je veux du rouge"
-			// fires "rouge"). Lowest priority: only reached when no phrase matched (#246).
 			if (singleWordKeys.length && trimmed.includes(' ')) {
 				for (const w of trimmed.split(/\s+/)) {
 					const commandKey = w.toLowerCase()
-					// A split word never contains a space, so this only ever hits single-word keys.
 					if (commandKey in normalized) {
 						const result = normalized[commandKey]?.(w, commandKey)
 						if (result !== null) return result

--- a/src/hooks/useCommands.ts
+++ b/src/hooks/useCommands.ts
@@ -58,13 +58,18 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 			if (!keys.length) return null
 
 			const trimmed = rawInput.trim()
+			const isMultiWord = /\s/.test(trimmed)
 
-			if (singleWordKeys.length && !trimmed.includes(' ')) {
-				const commandKey = trimmed.toLowerCase()
-				if (Object.hasOwn(normalized, commandKey)) {
-					const result = normalized[commandKey]?.(trimmed, commandKey)
-					if (result !== null) return result
-				}
+			// Returns null when `word` is not a registered single-word key, so the caller
+			// falls through to the next tier (a null callback result is also "no match").
+			const matchSingleWord = (word: string) => {
+				const commandKey = word.toLowerCase()
+				return Object.hasOwn(normalized, commandKey) ? normalized[commandKey]?.(word, commandKey) : null
+			}
+
+			if (singleWordKeys.length && !isMultiWord) {
+				const result = matchSingleWord(trimmed)
+				if (result !== null) return result
 			}
 
 			if (phraseKeys.length) {
@@ -72,7 +77,7 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 				if (fuse) {
 					const matches = fuse.search(rawInput).filter((r) => (r.score ?? 1) < precision)
 					if (matches.length) {
-						const commandKey = (matches[0].item as string).toLowerCase()
+						const commandKey = matches[0].item as string
 						const result = normalized[commandKey]?.(rawInput, commandKey)
 						if (result !== null) return result
 					}
@@ -91,13 +96,10 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 				}
 			}
 
-			if (singleWordKeys.length && trimmed.includes(' ')) {
+			if (singleWordKeys.length && isMultiWord) {
 				for (const w of trimmed.split(/\s+/)) {
-					const commandKey = w.toLowerCase()
-					if (Object.hasOwn(normalized, commandKey)) {
-						const result = normalized[commandKey]?.(w, commandKey)
-						if (result !== null) return result
-					}
+					const result = matchSingleWord(w)
+					if (result !== null) return result
 				}
 			}
 

--- a/src/hooks/useCommands.ts
+++ b/src/hooks/useCommands.ts
@@ -18,15 +18,18 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 
 	const keys = useMemo(() => Object.keys(normalized), [normalized])
 
-	// Fuzzy matching is only needed for phrase command keys.
-	// Single-word keys use exact case-insensitive lookup — simpler and no false positives.
-	const hasPhraseKeys = useMemo(() => keys.some((k) => k.includes(' ')), [keys])
+	// Partition keys by matching strategy. Single-word keys use exact case-insensitive
+	// lookup (simpler, no false positives); phrase keys use fuzzy matching. The two passes
+	// are independent so a mixed map keeps single-word matching working regardless of how
+	// many phrase keys it also contains.
+	const singleWordKeys = useMemo(() => keys.filter((k) => !k.includes(' ')), [keys])
+	const phraseKeys = useMemo(() => keys.filter((k) => k.includes(' ')), [keys])
 
 	// Lazy-loaded so consumers using only single-word commands incur no bundle cost.
 	const fuseRef = useRef<Fuse<string> | null>(null)
 
 	useEffect(() => {
-		if (!hasPhraseKeys) {
+		if (!phraseKeys.length) {
 			fuseRef.current = null
 			return
 		}
@@ -38,7 +41,10 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 			.then((module) => {
 				if (cancelled) return
 				const FuseCtor = (module.default ?? module) as unknown as typeof Fuse
-				fuseRef.current = new FuseCtor(keys, { includeScore: true, ignoreLocation: true })
+				// Index only phrase keys: single-word keys are handled by exact lookup, so
+				// indexing them here would let a typo'd single word fuzzy-match a key that
+				// is contractually exact-only.
+				fuseRef.current = new FuseCtor(phraseKeys, { includeScore: true, ignoreLocation: true })
 			})
 			.catch(() => {
 				if (cancelled) return
@@ -52,40 +58,72 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 		return () => {
 			cancelled = true
 		}
-	}, [hasPhraseKeys, keys])
+	}, [phraseKeys])
 
 	const triggerCommand = useCallback<TriggerCommand>(
 		(rawInput) => {
 			if (!keys.length) return null
 
-			if (!hasPhraseKeys) {
-				const words = rawInput.trim().split(/\s+/)
-				const targets = words.length > 1 ? words : [rawInput.trim()]
-				for (const w of targets) {
-					const commandKey = w.toLowerCase()
-					if (commandKey in normalized) return normalized[commandKey]?.(w, commandKey)
+			const trimmed = rawInput.trim()
+
+			// Three passes run in priority order; each returns the first command whose callback
+			// yields a non-null result. `null` is the documented "no match" sentinel (see
+			// tryMatchCommand in Vocal.tsx), so a callback that returns it falls through to the
+			// next pass instead of ending the scan.
+
+			// 1. Exact single-word command for the whole utterance. Highest priority so an
+			// intentional one-word command fires even when that word also appears inside a phrase
+			// key (e.g. "rouge" with a { rouge, 'change la bordure en rouge' } map).
+			if (singleWordKeys.length && !trimmed.includes(' ')) {
+				const commandKey = trimmed.toLowerCase()
+				if (commandKey in normalized) {
+					const result = normalized[commandKey]?.(trimmed, commandKey)
+					if (result !== null) return result
 				}
-				return null
 			}
 
-			const fuse = fuseRef.current
-			if (fuse) {
-				const result = fuse.search(rawInput).filter((r) => (r.score ?? 1) < precision)
-				if (result?.length) {
-					const commandKey = (result[0].item as string).toLowerCase()
-					return normalized[commandKey]?.(rawInput, commandKey)
+			// 2. Phrase keys via fuzzy matching (or substring fallback when fuse.js is absent).
+			// Runs before the per-word pass so an exact/near-exact phrase wins over a single-word
+			// key that merely appears inside it (#246: "change the background color" must fire the
+			// phrase, not the embedded "color").
+			if (phraseKeys.length) {
+				const fuse = fuseRef.current
+				if (fuse) {
+					const matches = fuse.search(rawInput).filter((r) => (r.score ?? 1) < precision)
+					if (matches.length) {
+						const commandKey = (matches[0].item as string).toLowerCase()
+						const result = normalized[commandKey]?.(rawInput, commandKey)
+						if (result !== null) return result
+					}
+				} else {
+					// `k.includes(lInput)` can produce false positives when input is short
+					// (e.g. "rouge" matches "change en rouge"). Accepted tradeoff: this branch
+					// only runs when fuse.js is absent, so degraded precision is expected.
+					const lInput = rawInput.toLowerCase()
+					const commandKey = phraseKeys.find((k) => lInput.includes(k) || k.includes(lInput))
+					if (commandKey) {
+						const result = normalized[commandKey]?.(rawInput, commandKey)
+						if (result !== null) return result
+					}
 				}
-			} else {
-				// `k.includes(lInput)` can produce false positives when input is short
-				// (e.g. "rouge" matches "change en rouge"). Accepted tradeoff: this branch
-				// only runs when fuse.js is absent, so degraded precision is expected.
-				const lInput = rawInput.toLowerCase()
-				const commandKey = keys.find((k) => lInput.includes(k) || k.includes(lInput))
-				if (commandKey) return normalized[commandKey]?.(rawInput, commandKey)
 			}
+
+			// 3. A single-word command embedded in a multi-word utterance ("je veux du rouge"
+			// fires "rouge"). Lowest priority: only reached when no phrase matched (#246).
+			if (singleWordKeys.length && trimmed.includes(' ')) {
+				for (const w of trimmed.split(/\s+/)) {
+					const commandKey = w.toLowerCase()
+					// A split word never contains a space, so this only ever hits single-word keys.
+					if (commandKey in normalized) {
+						const result = normalized[commandKey]?.(w, commandKey)
+						if (result !== null) return result
+					}
+				}
+			}
+
 			return null
 		},
-		[keys, normalized, hasPhraseKeys, precision]
+		[keys, normalized, singleWordKeys, phraseKeys, precision]
 	)
 
 	return triggerCommand


### PR DESCRIPTION
## Summary
A command map that mixed a single-word key with any phrase key (a key containing a space) routed every transcript through fuse.js, leaving the single-word exact lookup and per-word splitting dead. Single-word commands embedded in a phrase — e.g. _"je veux du rouge"_ firing `rouge` — silently stopped working.

`useCommands` now partitions keys into single-word and phrase subsets and matches them in priority order, so single-word and phrase commands coexist regardless of map composition.

## Changes
- **`useCommands`**: replaced the whole-map `hasPhraseKeys` switch with two key subsets and a three-tier matcher:
  1. exact whole-utterance single-word match,
  2. phrase fuzzy matching (fuse.js, or substring fallback when absent),
  3. a single word embedded in a multi-word transcript (the #246 case).

  The first callback returning a non-`null` value wins; a `null` result (the documented "no match" sentinel) falls through to the next tier. fuse.js is now indexed over phrase keys only.
- **Tests**: added a `Mixed command map` suite covering the #246 regression, both directions of single-word/phrase precedence, `null` fall-through, and a fuse-absent mixed map.
- **Docs**: documented the precedence rules in the README.
- **Demo**: the playground now mixes a phrase command with the single-word colour commands so it exercises the mixed-map path.

## Priority semantics
- `"rouge"` → fires `rouge` even when a phrase key also contains "rouge"
- `"change the background color"` → fires the phrase even though `color` is a single-word key
- `"je veux du rouge"` → fires `rouge` when no phrase matches

## Test plan
- [ ] `yarn test:ci` — 180 tests pass (new mixed-map regression tests included; the primary anchors fail against the pre-fix source)
- [ ] `yarn typecheck`
- [ ] `yarn lint`
- [ ] `yarn build`
- [ ] Demo builds and code-splits fuse.js (`cd dev && vite build`)

## ⚠️ Breaking changes
None. In a mixed map, single-word keys now use exact lookup — matching the documented contract and the behaviour of single-word-only maps — instead of being silently routed through fuzzy matching. This restores documented behaviour rather than changing a working one.

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)