### PR TITLE
build(deps): Bump undici, braces and js-yaml to patched versions

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1740,11 +1740,11 @@ brace-expansion@^5.0.5:
     balanced-match "^4.0.2"
 
 braces@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
-  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
+  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
-    fill-range "^7.0.1"
+    fill-range "^7.1.1"
 
 cacache@^20.0.0, cacache@^20.0.1, cacache@^20.0.4:
   version "20.0.4"
@@ -2455,10 +2455,10 @@ file-entry-cache@^8.0.0:
   dependencies:
     flat-cache "^4.0.0"
 
-fill-range@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
-  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+fill-range@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
+  integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
     to-regex-range "^5.0.1"
 
@@ -3032,9 +3032,9 @@ js-tokens@^4.0.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
+  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
   dependencies:
     argparse "^2.0.1"
 
@@ -5090,14 +5090,14 @@ uglify-js@^3.1.4:
   integrity sha512-xtB8yEqIkn7zmOyS2zUNBsYCBRhDkvlNxMMY2smuJ/qA8NCHeQvKCF3i9Z4k8FJH4+PJvZRtMrPynfZ75+CSZw==
 
 undici@^6.23.0, undici@^6.25.0:
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.25.0.tgz#8c4efb8c998dc187fc1cfb5dde1ef19a211849fb"
-  integrity sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==
+  version "6.27.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.27.0.tgz#41f9e48f7c5a40d27376caaead8c9a9fc7bca9c4"
+  integrity sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==
 
 undici@^7.0.0, undici@^7.25.0:
-  version "7.25.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.25.0.tgz#7d72fc429a0421769ca2966fd07cac875c85b781"
-  integrity sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 unicode-emoji-modifier-base@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## What

Bumps three **dev-only** transitive dependencies to their patched releases, within their existing semver ranges:

- **undici** `6.25.0 → 6.27.0` and `7.25.0 → 7.28.0`
- **braces** `3.0.2 → 3.0.3`
- **js-yaml** `4.1.1 → 4.2.0`

(`fill-range` `7.0.1 → 7.1.1` is pulled along as braces' in-range sub-dependency.)

## Why

Clears the following Dependabot alerts on the lockfile:

| Alert | Severity | Package | Advisory |
|---|---|---|---|
| #136 | **HIGH** | undici | GHSA-hm92-r4w5-c3mj — cross-origin request routing via SOCKS5 proxy pool reuse |
| #127 | **HIGH** | undici | GHSA-vmh5-mc38-953g — TLS certificate validation bypass via SOCKS5 ProxyAgent |
| #55 | **HIGH** | braces | CVE-2024-4068 / GHSA-grv7-fg5c-xmjg — uncontrolled resource consumption |
| #132 | MEDIUM | js-yaml | CVE-2026-53550 / GHSA-h67p-54hq-rp68 — quadratic-complexity DoS in merge-key handling |

The undici bump additionally clears the related medium/low undici advisories (#128, #139, #140, #134, #135, #141, #142). **In total this PR closes 11 alerts** (9 undici + braces + js-yaml).

## Impact

All packages are part of the **build / test / release toolchain** (undici via `semantic-release` and `jsdom`; braces via `@semantic-release/git` → `micromatch`; js-yaml via `cosmiconfig`). They are **never shipped** to consumers of `@untemps/react-vocal` — the published package contains only `dist/` + `@untemps/vocal` — so there is **no runtime impact**. The bumps stay within existing parent semver ranges (no major-version jumps), so toolchain breakage risk is minimal.

## Verification

- `yarn install` → lockfile coherent (already up-to-date)
- `yarn test:ci` → **171/171 pass**
- `yarn build` → OK
- Diff limited to `yarn.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
