### PR TITLE
fix(vocal): Continuous-mode regular timeout pre-empts silenceTimeout and auto-stops always-on sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ fuse.js is an optional peer dependency — install it separately to enable fuzzy
 | commands        | object            | null                 | Callbacks to be triggered when specified commands are detected by the recognition               |
 | lang            | string            | 'en-US'              | Language understood by the recognition [BCP 47 language tag](https://tools.ietf.org/html/bcp47) |
 | grammars        | SpeechGrammarList | null                 | Grammars understood by the recognition [JSpeech Grammar Format](https://www.w3.org/TR/jsgf/)    |
-| timeout         | number            | 3000                 | Time in ms to wait before discarding the recognition                                            |
+| timeout         | number            | 3000                 | Time in ms to wait before discarding the recognition. Not applied in continuous mode, where the session is governed by `silenceTimeout` or an explicit stop. |
 | precision       | number            | 0.4                  | Fuse.js score threshold for **phrase** command keys only (lower = stricter). Single-word commands always use exact lookup. |
 | maxAlternatives | number            | 1                    | Maximum number of recognition alternatives per segment. Setting this to 3–5 lets the engine surface the correct word as a secondary transcript, which is useful for handling homophones (e.g. _blue_ / _blew_). |
 | continuous      | boolean           | false                | Keep the recognition session open after each result. The session accumulates transcript across segments and stops when the button is clicked again or `silenceTimeout` expires. Commands are not evaluated in continuous mode. |

--- a/dev/src/index.jsx
+++ b/dev/src/index.jsx
@@ -15,6 +15,7 @@ const App = () => {
 	const [logs, setLogs] = useState('')
 	const [borderColor, setBorderColor] = useState()
 	const [continuous, setContinuous] = useState(false)
+	const [silenceTimeout, setSilenceTimeout] = useState(5000)
 	const [permission, setPermission] = useState(null)
 
 	const _log = (value) => setLogs((prev) => `${prev}${prev.length > 0 ? '\n' : ''} ----- ${value}`)
@@ -40,6 +41,7 @@ const App = () => {
 				lang="en-US"
 				commands={commands}
 				continuous={continuous}
+				silenceTimeout={silenceTimeout}
 				onStart={() => _log('start')}
 				onEnd={() => _log('end')}
 				onResult={(result) => _log(`transcript: "${result}"`)}
@@ -58,6 +60,22 @@ const App = () => {
 					<input type="checkbox" checked={continuous} onChange={(e) => setContinuous(e.target.checked)} />
 					Continuous mode
 				</label>
+			</p>
+			<p style={{ fontSize: 12, color: '#666', margin: '8px 0' }}>
+				<label style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+					Silence timeout (ms)
+					<input
+						type="number"
+						min={0}
+						step={500}
+						value={silenceTimeout ?? ''}
+						disabled={!continuous}
+						onChange={(e) => setSilenceTimeout(e.target.value === '' ? null : Number(e.target.value))}
+						style={{ width: 80 }}
+					/>
+				</label>
+				— in continuous mode the session auto-stops after this many ms of silence; leave empty (or 0) to
+				require a button click
 			</p>
 			<p style={{ fontSize: 12, color: '#666', margin: '8px 0' }}>
 				Commands:{' '}

--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -215,7 +215,10 @@ export const Vocal = ({
 
 	const _onStart = useCallback(
 		(e: Event) => {
-			startTimer()
+			// The regular timeout discards a session that yields no speech. In continuous mode it
+			// must not run at all — an always-on session ends only on an explicit stop or
+			// silenceTimeout — otherwise it would kill the session ~timeout ms after start.
+			if (!continuousRef.current) startTimer()
 			propsRef.current.onStart?.(e)
 		},
 		[startTimer]
@@ -232,11 +235,16 @@ export const Vocal = ({
 
 	const _onSpeechEnd = useCallback(
 		(e: Event) => {
-			startTimer()
-			// silenceTimeout fires stop() after N ms of silence following speech in continuous mode.
-			// Anchored on speechend because vocal 2.x intercepts intermediate result events in continuous mode,
-			// so _onResult only runs once on the aggregated end-of-session event.
-			if (continuousRef.current && (silenceTimeoutRef.current ?? 0) > 0) startSilenceTimer()
+			if (continuousRef.current) {
+				// Continuous sessions are governed only by silenceTimeout (or an explicit stop),
+				// never by the regular timeout — re-arming it here would race silenceTimeout and
+				// auto-stop the always-on session. silenceTimeout is anchored on speechend because
+				// vocal 2.x intercepts intermediate result events in continuous mode, so _onResult
+				// only runs once on the aggregated end-of-session event.
+				if ((silenceTimeoutRef.current ?? 0) > 0) startSilenceTimer()
+			} else {
+				startTimer()
+			}
 			propsRef.current.onSpeechEnd?.(e)
 		},
 		[startTimer, startSilenceTimer]

--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -215,9 +215,6 @@ export const Vocal = ({
 
 	const _onStart = useCallback(
 		(e: Event) => {
-			// The regular timeout discards a session that yields no speech. In continuous mode it
-			// must not run at all — an always-on session ends only on an explicit stop or
-			// silenceTimeout — otherwise it would kill the session ~timeout ms after start.
 			if (!continuousRef.current) startTimer()
 			propsRef.current.onStart?.(e)
 		},
@@ -236,11 +233,6 @@ export const Vocal = ({
 	const _onSpeechEnd = useCallback(
 		(e: Event) => {
 			if (continuousRef.current) {
-				// Continuous sessions are governed only by silenceTimeout (or an explicit stop),
-				// never by the regular timeout — re-arming it here would race silenceTimeout and
-				// auto-stop the always-on session. silenceTimeout is anchored on speechend because
-				// vocal 2.x intercepts intermediate result events in continuous mode, so _onResult
-				// only runs once on the aggregated end-of-session event.
 				if ((silenceTimeoutRef.current ?? 0) > 0) startSilenceTimer()
 			} else {
 				startTimer()

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -1162,21 +1162,21 @@ describe('Vocal', () => {
 			expect(commandFn).not.toHaveBeenCalled()
 		})
 
-		it('auto-stops after silenceTimeout ms of inactivity following last result', async () => {
+		it('auto-stops at silenceTimeout, not at the shorter regular timeout', async () => {
 			vi.useFakeTimers()
 			const onEnd = vi.fn()
 			const onResult = vi.fn()
 			const recognition = createMockVocal({ continuous: true })
-			// timeout bumped above silenceTimeout so the regular timer cannot fire first —
-			// both timers share stableTimerCb, so a shorter `timeout` would mask which one
-			// actually triggered _onEnd.
+			// Regular timeout (3000) is deliberately SHORTER than silenceTimeout (5000): in
+			// continuous mode the regular timer must never arm, so the session has to survive
+			// past t=3000 and end only when silenceTimeout elapses at t=5000.
 			const { getByTestId } = render(
 				getInstance({
 					__rsInstance: recognition,
 					onEnd,
 					onResult,
 					continuous: true,
-					timeout: 10_000,
+					timeout: 3000,
 					silenceTimeout: 5000,
 				})
 			)
@@ -1185,24 +1185,61 @@ describe('Vocal', () => {
 				fireEvent.click(getByTestId('__vocal-root__'))
 			})
 
+			// speechend arms the silence timer at t=0 (fires at t=5000).
 			act(() => {
 				recognition.say('Hello')
 			})
-
 			expect(onEnd).not.toHaveBeenCalled()
 
+			// Past the regular timeout deadline (t=3000): with the bug the regular timer would
+			// have ended the session here. It must still be alive.
 			act(() => {
-				vi.advanceTimersByTime(4999)
+				vi.advanceTimersByTime(3000)
 			})
 			expect(onEnd).not.toHaveBeenCalled()
 
+			// Just before the silence deadline (t=4999): still alive.
+			act(() => {
+				vi.advanceTimersByTime(1999)
+			})
+			expect(onEnd).not.toHaveBeenCalled()
+
+			// silenceTimeout elapses at t=5000.
 			act(() => {
 				vi.advanceTimersByTime(1)
 			})
-
 			expect(onEnd).toHaveBeenCalledTimes(1)
 			expect(onResult).toHaveBeenCalledTimes(1)
 			expect(onResult).toHaveBeenCalledWith('Hello', expect.anything())
+			vi.useRealTimers()
+		})
+
+		it('keeps an always-on session alive past the regular timeout when no speech occurs', async () => {
+			vi.useFakeTimers()
+			const onEnd = vi.fn()
+			const recognition = createMockVocal({ continuous: true })
+			// Default config: silenceTimeout disabled, so only an explicit stop ends the session.
+			// _onStart must not arm the regular timer in continuous mode, otherwise the session
+			// would die ~timeout ms after start even though the user never spoke.
+			const { getByTestId } = render(
+				getInstance({
+					__rsInstance: recognition,
+					onEnd,
+					continuous: true,
+					timeout: 3000,
+				})
+			)
+
+			await act(async () => {
+				fireEvent.click(getByTestId('__vocal-root__'))
+			})
+
+			// Well past the regular timeout deadline with no speech: the session stays open.
+			act(() => {
+				vi.advanceTimersByTime(10_000)
+			})
+			expect(onEnd).not.toHaveBeenCalled()
+			expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-pressed', 'true')
 			vi.useRealTimers()
 		})
 
@@ -1210,12 +1247,15 @@ describe('Vocal', () => {
 			vi.useFakeTimers()
 			const onEnd = vi.fn()
 			const recognition = createMockVocal({ continuous: true })
+			// Regular timeout (3000) stays below the silence deadlines on purpose: in continuous
+			// mode it must never arm, so it can elapse during the windows below without ending
+			// the session — only the silence timer drives auto-stop.
 			const { getByTestId } = render(
 				getInstance({
 					__rsInstance: recognition,
 					onEnd,
 					continuous: true,
-					timeout: 10_000,
+					timeout: 3000,
 					silenceTimeout: 5000,
 				})
 			)

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -1167,9 +1167,6 @@ describe('Vocal', () => {
 			const onEnd = vi.fn()
 			const onResult = vi.fn()
 			const recognition = createMockVocal({ continuous: true })
-			// Regular timeout (3000) is deliberately SHORTER than silenceTimeout (5000): in
-			// continuous mode the regular timer must never arm, so the session has to survive
-			// past t=3000 and end only when silenceTimeout elapses at t=5000.
 			const { getByTestId } = render(
 				getInstance({
 					__rsInstance: recognition,
@@ -1185,26 +1182,21 @@ describe('Vocal', () => {
 				fireEvent.click(getByTestId('__vocal-root__'))
 			})
 
-			// speechend arms the silence timer at t=0 (fires at t=5000).
 			act(() => {
 				recognition.say('Hello')
 			})
 			expect(onEnd).not.toHaveBeenCalled()
 
-			// Past the regular timeout deadline (t=3000): with the bug the regular timer would
-			// have ended the session here. It must still be alive.
 			act(() => {
 				vi.advanceTimersByTime(3000)
 			})
 			expect(onEnd).not.toHaveBeenCalled()
 
-			// Just before the silence deadline (t=4999): still alive.
 			act(() => {
 				vi.advanceTimersByTime(1999)
 			})
 			expect(onEnd).not.toHaveBeenCalled()
 
-			// silenceTimeout elapses at t=5000.
 			act(() => {
 				vi.advanceTimersByTime(1)
 			})
@@ -1218,9 +1210,6 @@ describe('Vocal', () => {
 			vi.useFakeTimers()
 			const onEnd = vi.fn()
 			const recognition = createMockVocal({ continuous: true })
-			// Default config: silenceTimeout disabled, so only an explicit stop ends the session.
-			// _onStart must not arm the regular timer in continuous mode, otherwise the session
-			// would die ~timeout ms after start even though the user never spoke.
 			const { getByTestId } = render(
 				getInstance({
 					__rsInstance: recognition,
@@ -1234,7 +1223,6 @@ describe('Vocal', () => {
 				fireEvent.click(getByTestId('__vocal-root__'))
 			})
 
-			// Well past the regular timeout deadline with no speech: the session stays open.
 			act(() => {
 				vi.advanceTimersByTime(10_000)
 			})
@@ -1247,9 +1235,6 @@ describe('Vocal', () => {
 			vi.useFakeTimers()
 			const onEnd = vi.fn()
 			const recognition = createMockVocal({ continuous: true })
-			// Regular timeout (3000) stays below the silence deadlines on purpose: in continuous
-			// mode it must never arm, so it can elapse during the windows below without ending
-			// the session — only the silence timer drives auto-stop.
 			const { getByTestId } = render(
 				getInstance({
 					__rsInstance: recognition,


### PR DESCRIPTION
## Summary
In continuous mode the regular `timeout` timer (default 3000ms) was armed and re-armed with no `continuous` gate, so it raced the `silenceTimeout` timer and ended always-on sessions ~3s after silence. Any `silenceTimeout >= timeout` was silently overridden. This fix stops the regular timeout from governing continuous sessions: they are now driven only by `silenceTimeout` or an explicit stop, matching the documented behavior.

## Changes
- **`src/components/Vocal.tsx`** — gate both unconditional `startTimer()` calls (`_onStart` and `_onSpeechEnd`) behind non-continuous mode. In continuous mode only the silence timer (when `silenceTimeout > 0`) is armed; non-continuous behavior is unchanged.
- **`src/components/__tests__/Vocal.test.tsx`** — drop the `timeout: 10_000` pin that masked the bug; exercise continuous mode with the default-shorter `timeout` (3000) and a longer `silenceTimeout` (5000), asserting the session survives past `timeout` and ends at `silenceTimeout`. Add a test that an always-on session with no speech stays alive past `timeout` (covers the `_onStart` gate). Tighten the rearm test to the shorter timeout so it also guards the regression.
- **`dev/src/index.jsx`** — add a numeric `silenceTimeout` control (disabled outside continuous mode) so the precedence behavior is testable in the playground.
- **`README.md`** — note that `timeout` is not applied in continuous mode.

## Test plan
- [x] `yarn test:ci` — 189 tests pass (`Vocal.tsx` at 100%)
- [x] The three continuous-timer tests were verified to **fail** against the pre-fix `Vocal.tsx` and pass after — genuine regression guards
- [x] `yarn typecheck`, `yarn lint`, `yarn build` all green
- [x] `yarn dev` boots cleanly; continuous mode no longer auto-stops at `timeout`, and the new control demonstrates `silenceTimeout` precedence
- [x] Adversarial multi-agent review of the diff — 0 confirmed findings

Closes #247