### PR TITLE
docs: Correct continuous mode disclaimer to match actual behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ far (see [caniuse](https://caniuse.com/#search=SpeechRecognition)). If the API i
 won't display anything.
 
 This component intends to catch a speech result as soon as possible. This can be a good fit for vocal commands or search
-field filling. It also supports a continuous mode (`continuous` prop) for real-time transcription and always-on voice
-command use cases — see the `Vocal` component API table for details.
+field filling. It also supports a continuous mode (`continuous` prop) that keeps the recognition session open across
+speech segments and delivers a single, aggregated transcript through `onResult` when the session ends — stopped by a
+second click or by `silenceTimeout`. Commands are not evaluated in continuous mode; see the `Vocal` component API table
+for details.
 
 In single-shot mode (the default), either a result is caught and returned or the timeout is reached and the recognition
 is discarded. The `stop` function returned by children-as-function mechanism allows to prematurely discard the


### PR DESCRIPTION
## Summary
The README Disclaimer claimed continuous mode is for "real-time transcription and always-on voice command use cases." Both claims contradict the actual behavior and the README's own API table. This reword describes what continuous mode really does and drops the false framing.

## Changes
- `README.md` (Disclaimer): replace the "real-time transcription and always-on voice command use cases" sentence with an accurate description — continuous mode keeps the recognition session open across speech segments and delivers a single, aggregated transcript through `onResult` when the session ends (stopped by a second click or by `silenceTimeout`), and commands are not evaluated in continuous mode. Keeps the pointer to the `Vocal` component API table.

## Why the old wording was wrong
- **No real-time transcription:** `useVocal` builds the instance without `interimResults` (`src/hooks/useVocal.ts:43`); `@untemps/vocal` emits a single aggregated event just before `end`, so `onResult` fires once with the full session transcript — not incrementally.
- **No always-on voice commands:** command matching is gated off in continuous mode (`src/components/Vocal.tsx:251`, `if (!continuousRef.current)`). The API table (`README.md:278`) already states commands are not evaluated in continuous mode.

The new wording reuses the API table's exact verbs so the Disclaimer and the table no longer contradict each other.

## Test plan
- [x] `yarn typecheck` — passes
- [x] `yarn lint` — passes
- [x] `yarn build` — passes
- [x] `yarn test:ci` — 189/189 passing
- [x] Read the rendered Disclaimer and confirm it no longer mentions real-time transcription or always-on commands, and matches the `Vocal` component API table.

Closes #248