### PR TITLE
docs: Correct what isSupported() checks (Permissions API is not part of the check)

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ Matching rules:
 
 #### Basic usage
 
-`isSupported` is a function that returns `true` when the browser supports the Web Speech API (along with the Permissions and MediaDevices APIs that `@untemps/vocal` relies on). It is safe to call during server-side rendering — it returns `false` when `window` is undefined.
+`isSupported` is a function that returns `true` when the browser supports the Web Speech API and the MediaDevices API that `@untemps/vocal` relies on. (The Permissions API is used at runtime to watch microphone permission, but it is not part of the support check.) It is safe to call during server-side rendering — it returns `false` when `window` is undefined.
 
 ```javascript
 import { Vocal, isSupported } from '@untemps/react-vocal'


### PR DESCRIPTION
## Summary
The "Browser support flag" section of the README stated that `isSupported` returns `true` when the browser supports the Web Speech API "along with the Permissions and MediaDevices APIs." The actual check does not include the Permissions API. This corrects the wording so the documented behavior matches the implementation.

## Context
`isSupported` is re-exported from `@untemps/vocal` (`src/index.ts`). In `@untemps/vocal` 2.2.0 it is defined as `isSupported = () => !!SpeechRecognitionCtor() && isMediaDevicesSupported()` — only SpeechRecognition and MediaDevices are checked. `isPermissionsSupported` exists in the library and is used by the permission-watching path, but it is **not** referenced by `isSupported`. The previous wording therefore overstated the gating conditions.

## Changes
- `README.md` — Reword the `isSupported` description to list only the Web Speech API and the MediaDevices API as the APIs gating the result, with a short note clarifying that the Permissions API is used at runtime to watch microphone permission but is not part of the support check.

## Test plan
- [x] Read the updated "Browser support flag" section and confirm it no longer claims the Permissions API gates `isSupported`.
- [x] `yarn test:ci` — green (189 tests)
- [x] `yarn typecheck` — green
- [x] `yarn lint` — green
- [x] `yarn build` — green

Documentation only; no behavior change.

Closes #250