### PR TITLE
test: Assert the useCommands hook return value instead of the renderHook wrapper

### DIFF
--- a/src/hooks/__tests__/useCommands.test.ts
+++ b/src/hooks/__tests__/useCommands.test.ts
@@ -14,8 +14,8 @@ vi.mock('fuse.js', async () => {
 
 describe('useCommands', () => {
 	it('returns triggerCommand function', () => {
-		const triggerCommand = renderHook(() => useCommands())
-		expect(triggerCommand).toBeDefined()
+		const { result } = renderHook(() => useCommands())
+		expect(typeof result.current).toBe('function')
 	})
 
 	it('returns a stable triggerCommand across renders when commands prop is referentially equal', () => {


### PR DESCRIPTION
## Summary
The `'returns triggerCommand function'` test in `useCommands.test.ts` bound the entire `RenderHookResult` object to a variable named `triggerCommand` and only asserted it was defined. Since `renderHook()` always returns a defined `{ result, rerender, unmount }` wrapper, the assertion passed trivially and never read the hook's real output (`.result.current`) — it would still pass if `useCommands` returned `undefined` or a non-function.

This corrects the test to read the hook's actual return value and assert it is a function, matching the shape every other test in the file already uses.

## Changes
- `src/hooks/__tests__/useCommands.test.ts`: destructure `result` from `renderHook()` and assert `typeof result.current === 'function'` instead of asserting the wrapper is defined.

## Test plan
- [x] `yarn test:ci` — full suite passes (189 tests)
- [x] `yarn typecheck` — no type errors
- [x] `yarn lint` — no lint errors
- [x] The corrected test now fails if the hook returns a non-function

Closes #251