### PR TITLE
test: Assert useVocal creates and assigns the SpeechRecognition instance

### DIFF
--- a/src/hooks/__tests__/useVocal.test.ts
+++ b/src/hooks/__tests__/useVocal.test.ts
@@ -129,7 +129,8 @@ describe('useVocal', () => {
 					current: [ref],
 				},
 			} = renderHook(() => useVocal())
-			expect(ref.current).toBeDefined()
+			const instance = vi.mocked(createVocal).mock.results[0].value
+			expect(ref.current).toBe(instance)
 		})
 
 		it('passes maxAlternatives to createVocal factory', () => {


### PR DESCRIPTION
## Summary
The supported-branch test `'creates SpeechRecognition instance'` in `src/hooks/__tests__/useVocal.test.ts` asserted instance creation with `expect(ref.current).toBeDefined()`. In vitest, `toBeDefined()` only fails for `undefined` — `null` counts as defined — so the test passed whether or not the instance was actually created and assigned. A regression in the `ref.current = instance` assignment (`useVocal.ts:44`) would have gone undetected.

## Changes
- Capture the object returned by the mocked `createVocal` (`vi.mocked(createVocal).mock.results[0].value`) and assert `expect(ref.current).toBe(instance)`. This is stronger than `.not.toBeNull()`: it confirms `ref.current` holds the exact instance the factory returned, directly covering the assignment line at risk.

## Test plan
- [x] `yarn test:ci` — 189 tests pass
- [x] `yarn typecheck` — clean
- [x] `yarn lint` — clean
- [x] Regression check: temporarily commenting out `ref.current = instance` now makes this test fail (with the old `toBeDefined()` it still passed)

Closes #252