### PR TITLE
fix: Short transcripts falsely trigger phrase commands (Fuse missing minMatchCharLength)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ fuse.js is an optional peer dependency — install it separately to enable fuzzy
 
 **Single-word command keys** (e.g. `red`, `submit`) use exact case-insensitive lookup. When the recognition returns a multi-word transcript, each word is tried individually so a command fires even when embedded in a phrase (e.g. _"I want some red"_ triggers `red`).
 
-**Phrase command keys** (e.g. `'Change the background color'`) use [fuse.js](https://fusejs.io/) fuzzy matching. The `precision` prop controls the Fuse.js score threshold (default `0.4` — lower is stricter).
+**Phrase command keys** (e.g. `'Change the background color'`) use [fuse.js](https://fusejs.io/) fuzzy matching against multi-word transcripts. The `precision` prop controls the Fuse.js score threshold (default `0.4` — lower is stricter). A single-word transcript never fuzzy-matches a phrase key, so a stray fragment (`"the"`, `"to"`) returned by the recognition can't trigger a phrase command.
 
 **Mixing single-word and phrase keys** is fully supported — a phrase key never disables single-word matching. For each transcript the hook tries, in order: (1) an exact match of the whole utterance against a single-word key, (2) fuzzy matching against the phrase keys, then (3) each word of the utterance against the single-word keys. The first command whose callback returns a non-`null` value wins (returning `null` is treated as "no match" and falls through to the next step). So an exact phrase like _"change the background color"_ fires the phrase even when a single-word key (`color`) appears inside it, while an embedded single word like _"I want some red"_ still fires `red` when no phrase matches.
 
@@ -458,7 +458,7 @@ useCommands(commands, precision)
 Matching rules:
 
 - **Single-word keys** (e.g. `red`, `submit`): exact case-insensitive lookup, with each word of the input tried individually so a key fires even when embedded in a phrase (`I want some red` triggers `red`).
-- **Phrase keys** (e.g. `change the background color`): Fuse.js fuzzy matching against the joined transcript, gated by `precision`. fuse.js is loaded lazily; if it's not installed, the hook falls back to substring matching.
+- **Phrase keys** (e.g. `change the background color`): Fuse.js fuzzy matching against the joined multi-word transcript, gated by `precision`. A single-word transcript is never fuzzy-matched against a phrase key. fuse.js is loaded lazily; if it's not installed, the hook falls back to substring matching.
 - **Precedence** (mixed maps): an exact single-word utterance is tried first, then phrase fuzzy matching, then single words embedded in a multi-word transcript. The first command whose callback returns a non-`null` value wins; a `null` return is treated as no-match and falls through.
 
 ### Browser support flag

--- a/src/hooks/__tests__/useCommands.test.ts
+++ b/src/hooks/__tests__/useCommands.test.ts
@@ -248,6 +248,51 @@ describe('useCommands', () => {
 		})
 	})
 
+	describe('Fuse-present short-input guard', () => {
+		it.each([
+			['stop the music', 'the'],
+			['stop the music', 'to'],
+			['change the background color', 'a'],
+			['change the background color', 'c'],
+			['change the border to red', 'to'],
+			['change the border to red', 'der'],
+		])('does not fire phrase %p on the short single-word transcript %p', async (command, input) => {
+			const phrase = vi.fn(() => 'fired')
+			const {
+				result: { current: triggerCommand },
+			} = renderHook(() => useCommands({ [command]: phrase }))
+			await act(async () => {})
+			expect(triggerCommand(input)).toBeNull()
+			expect(phrase).not.toHaveBeenCalled()
+		})
+
+		it('does not fire either of two near-identical phrases on a short single-word transcript', async () => {
+			const toRed = vi.fn(() => 'red')
+			const toBlue = vi.fn(() => 'blue')
+			const {
+				result: { current: triggerCommand },
+			} = renderHook(() =>
+				useCommands({ 'change the border to red': toRed, 'change the border to blue': toBlue })
+			)
+			await act(async () => {})
+			for (const input of ['the', 'to', 'a']) {
+				expect(triggerCommand(input)).toBeNull()
+			}
+			expect(toRed).not.toHaveBeenCalled()
+			expect(toBlue).not.toHaveBeenCalled()
+		})
+
+		it('still fires a phrase command on a genuine multi-word transcript', async () => {
+			const phrase = vi.fn(() => 'changed')
+			const {
+				result: { current: triggerCommand },
+			} = renderHook(() => useCommands({ 'change the background color': phrase }))
+			await act(async () => {})
+			expect(triggerCommand('change the background colour')).toBe('changed')
+			expect(phrase).toHaveBeenCalled()
+		})
+	})
+
 	describe('Object-prototype key safety', () => {
 		it('does not treat an inherited Object.prototype name as a registered command', () => {
 			const commands = { red: () => 'red' }

--- a/src/hooks/useCommands.ts
+++ b/src/hooks/useCommands.ts
@@ -37,10 +37,6 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 			.then((module) => {
 				if (cancelled) return
 				const FuseCtor = (module.default ?? module) as unknown as typeof Fuse
-				// `minMatchCharLength: 2` drops single-character match segments so a stray
-				// letter (e.g. "a", "c") can't score near zero against a phrase key. It does
-				// not, on its own, block short whole-word fragments ("the", "to", "der") —
-				// the multi-word guard in triggerCommand handles those.
 				fuseRef.current = new FuseCtor(phraseKeys, {
 					includeScore: true,
 					ignoreLocation: true,
@@ -81,11 +77,6 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 			if (phraseKeys.length) {
 				const fuse = fuseRef.current
 				if (fuse) {
-					// Only multi-word transcripts can be a meaningful match for a (multi-word)
-					// phrase key. With `ignoreLocation`, a single short word that happens to be a
-					// substring of a phrase scores near zero (e.g. "the"/"to"/"der"), so a stray
-					// fragment would otherwise fire the wrong command. Single words are still
-					// handled by the exact single-word lookup above and the embedded scan below.
 					if (isMultiWord) {
 						const matches = fuse.search(rawInput).filter((r) => (r.score ?? 1) < precision)
 						if (matches.length) {

--- a/src/hooks/useCommands.ts
+++ b/src/hooks/useCommands.ts
@@ -37,7 +37,15 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 			.then((module) => {
 				if (cancelled) return
 				const FuseCtor = (module.default ?? module) as unknown as typeof Fuse
-				fuseRef.current = new FuseCtor(phraseKeys, { includeScore: true, ignoreLocation: true })
+				// `minMatchCharLength: 2` drops single-character match segments so a stray
+				// letter (e.g. "a", "c") can't score near zero against a phrase key. It does
+				// not, on its own, block short whole-word fragments ("the", "to", "der") —
+				// the multi-word guard in triggerCommand handles those.
+				fuseRef.current = new FuseCtor(phraseKeys, {
+					includeScore: true,
+					ignoreLocation: true,
+					minMatchCharLength: 2,
+				})
 			})
 			.catch(() => {
 				if (cancelled) return
@@ -73,11 +81,18 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 			if (phraseKeys.length) {
 				const fuse = fuseRef.current
 				if (fuse) {
-					const matches = fuse.search(rawInput).filter((r) => (r.score ?? 1) < precision)
-					if (matches.length) {
-						const commandKey = matches[0].item as string
-						const result = normalized[commandKey]?.(rawInput, commandKey)
-						if (result !== null) return result
+					// Only multi-word transcripts can be a meaningful match for a (multi-word)
+					// phrase key. With `ignoreLocation`, a single short word that happens to be a
+					// substring of a phrase scores near zero (e.g. "the"/"to"/"der"), so a stray
+					// fragment would otherwise fire the wrong command. Single words are still
+					// handled by the exact single-word lookup above and the embedded scan below.
+					if (isMultiWord) {
+						const matches = fuse.search(rawInput).filter((r) => (r.score ?? 1) < precision)
+						if (matches.length) {
+							const commandKey = matches[0].item as string
+							const result = normalized[commandKey]?.(rawInput, commandKey)
+							if (result !== null) return result
+						}
 					}
 				} else if (trimmed) {
 					// `k.includes(lInput)` can produce false positives when input is short


### PR DESCRIPTION
## Summary
Short or stray transcripts (single characters, common words like `the`/`to`/`a`) were falsely triggering **phrase** commands when fuse.js was installed. With `ignoreLocation: true` and no length guard, a tiny query that is a substring of a phrase key scores near zero — far below the default `precision` threshold of `0.4` — so the fuzzy search accepted it.

This adds a `minMatchCharLength` guard to the Fuse options and gates the fuzzy phrase search behind a multi-word check, so a single-word fragment can no longer match a multi-word phrase key.

## Changes
- `src/hooks/useCommands.ts`:
  - Add `minMatchCharLength: 2` to the Fuse constructor — drops single-character match segments (the `'a'`/`'c'` class) and addresses the root cause named in the issue.
  - Gate the fuse-present fuzzy search behind `isMultiWord`. A single-word transcript cannot be a meaningful match for a multi-word phrase key, so stray fragments (`'the'`, `'to'`, `'der'`) no longer fire a phrase command. `minMatchCharLength` alone does **not** block these — they match whole tokens inside the phrase — so the word-count guard is what fixes them.
  - The fuse-**absent** fallback keeps its documented single-word substring tradeoff unchanged.
- `src/hooks/__tests__/useCommands.test.ts`: add a `Fuse-present short-input guard` regression block (the path the issue notes was previously untested).
- `README.md`: clarify that fuzzy phrase matching applies to multi-word transcripts.

## Behavior change (precision tightening)
A single-word transcript that previously fuzzy-fired a phrase command (only when fuse.js was installed) no longer does — which is exactly the bug being fixed. No public API change. Single-word exact lookup, embedded-word scanning, and the fuse-absent fallback are unaffected.

## Test plan
- [x] `yarn test:ci` — 197 tests pass, including the new short-input regression cases (`'the'`/`'to'`/`'a'`/`'c'`/`'der'` no longer fire; near-identical twin phrases fire neither; genuine multi-word utterances still fire)
- [x] `yarn build`
- [x] `yarn typecheck`
- [x] `yarn lint`

Closes #261