### PR TITLE
fix: Default mic button lacks type="button" and submits an enclosing form

### DIFF
--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -331,6 +331,7 @@ export const Vocal = ({
 
 	const _renderDefault = () => (
 		<button
+			type="button"
 			data-testid="__vocal-root__"
 			aria-label={ariaLabel}
 			aria-pressed={isListening}

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -1,4 +1,4 @@
-import { type MouseEvent as ReactMouseEvent } from 'react'
+import { type FormEvent as ReactFormEvent, type MouseEvent as ReactMouseEvent } from 'react'
 import { waitFor } from '@testing-library/dom'
 import { act, fireEvent, render } from '@testing-library/react'
 import { createVocal, isSupported, type VocalInstance } from '@untemps/vocal'
@@ -275,6 +275,18 @@ describe('Vocal', () => {
 		const { getByTestId } = render(getInstance())
 		fireEvent.click(getByTestId('__vocal-root__'))
 		expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-pressed', 'true')
+	})
+
+	it('renders the default button with type="button" so it never submits an enclosing form', () => {
+		const { getByTestId } = render(getInstance())
+		expect(getByTestId('__vocal-root__')).toHaveAttribute('type', 'button')
+	})
+
+	it('does not submit an enclosing form when the default button is clicked', () => {
+		const onSubmit = vi.fn((event: ReactFormEvent<HTMLFormElement>) => event.preventDefault())
+		const { getByTestId } = render(<form onSubmit={onSubmit}>{getInstance()}</form>)
+		fireEvent.click(getByTestId('__vocal-root__'))
+		expect(onSubmit).not.toHaveBeenCalled()
 	})
 
 	it('renders the default outline when focused', () => {

--- a/src/components/__tests__/__snapshots__/Vocal.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Vocal.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`Vocal > matches snapshot 1`] = `
     aria-pressed="false"
     data-testid="__vocal-root__"
     style="width: 24px; height: 24px; background-color: transparent; border: medium; padding: 0px; cursor: pointer; outline: none;"
+    type="button"
   >
     <svg
       aria-hidden="true"


### PR DESCRIPTION
## Summary
The library-owned default mic `<button>` declared no `type` attribute, so per the HTML spec it defaulted to `type="submit"`. When a consumer places `<Vocal>` inside a `<form>`, clicking the mic submitted the form, and pressing Enter in a sibling input activated the mic button instead of submitting. This adds `type="button"` so the control never participates in form submission.

## Changes
- `src/components/Vocal.tsx` — add `type="button"` to the default mic button rendered by `_renderDefault()`.
- `src/components/__tests__/Vocal.test.tsx` — add two tests: one asserting the default button carries `type="button"`, and a behavioral one rendering `<form onSubmit>{<Vocal/>}</form>` and asserting a click does **not** submit the form.
- `src/components/__tests__/__snapshots__/Vocal.test.tsx.snap` — regenerated to reflect the new attribute.

## Test plan
- [x] `yarn test:ci` — 199 tests pass; `Vocal.tsx` at 100% statement/line/function coverage
- [x] `yarn build` — ES + CJS + `.d.ts` build clean
- [x] `yarn typecheck` — no errors
- [x] `yarn lint` — no errors
- [x] Demo (`dev/`) builds against the modified source
- [x] Regression guard verified: reverting the fix makes the form-submission test fail (jsdom fires the form's `submit` event for a `type="submit"` button)

## Notes
- Non-breaking: `type` is library-owned (not a `VocalProps` field) and does not change any behavior outside a `<form>`.
- Out of scope: consumers who pass a bare `<button>` as a custom child (the `cloneElement` path) still inherit the native `type="submit"`. That element is consumer-owned and pre-existing behavior, unrelated to this fix.

Closes #262