### PR TITLE
fix(build): Externalize react/jsx-runtime so dist works on React <19

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Although the lack of `SpeechGrammar` and `SpeechGrammarList` is handled by the u
 
 ## Requirements
 
--   React >= 16.13.1
+-   React >= 16.14.0
 -   Node >= 22
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -76,8 +76,8 @@
 	},
 	"peerDependencies": {
 		"fuse.js": ">=7.0.0",
-		"react": ">=16.13.1",
-		"react-dom": ">=16.13.1",
+		"react": ">=16.14.0",
+		"react-dom": ">=16.14.0",
 		"typescript": ">=6.0.0"
 	},
 	"peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -143,6 +143,8 @@
 		"typecheck": "tsc --noEmit",
 		"lint": "eslint src vitest.setup.ts dev/src",
 		"build": "vite build",
+		"postbuild": "node scripts/verify-bundle.mjs",
+		"verify:bundle": "node scripts/verify-bundle.mjs",
 		"prepare": "husky",
 		"prettier": "prettier \"*/**/*.{js,ts,tsx}\" --ignore-path ./.prettierignore --write && git add -u && git status"
 	}

--- a/scripts/verify-bundle.mjs
+++ b/scripts/verify-bundle.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * Build guard for issue #267.
+ *
+ * The published bundles must leave React's automatic JSX runtime external so
+ * element creation is performed by the *consumer's* React. If the runtime gets
+ * inlined (e.g. because `rollupOptions.external` stops matching the
+ * `react/jsx-runtime` subpath), the bundle embeds a build-time copy of React's
+ * jsx factory and stamps elements with that React version's element symbol,
+ * which crashes every consumer on a different major (React 16/17/18 only accept
+ * `Symbol.for('react.element')`, React 19 uses `react.transitional.element`).
+ *
+ * This script fails the build if either bundle:
+ *   - inlines a React element symbol (`react.transitional.element` / `react.element`), or
+ *   - does not reference the external `react/jsx-runtime` module.
+ */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+// Derive the bundles to check from package.json's entry points so this guard
+// never drifts from the actual build output (`module` -> ESM, `main` -> CJS).
+const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'))
+const bundles = [...new Set([pkg.module, pkg.main].filter(Boolean))]
+
+// React element symbols that must never be inlined (they would pin element
+// creation to the build's React version). `react.transitional.element` is
+// React 19's symbol; `react.element` is the classic one used by React <19.
+const inlinedElementSymbols = ['react.transitional.element', 'react.element']
+
+const errors = []
+
+for (const bundle of bundles) {
+	let source
+	try {
+		source = readFileSync(join(root, bundle), 'utf8')
+	} catch {
+		errors.push(`${bundle}: file not found — run \`yarn build\` first.`)
+		continue
+	}
+
+	for (const symbol of inlinedElementSymbols) {
+		if (source.includes(symbol)) {
+			errors.push(
+				`${bundle}: inlined React element symbol "${symbol}" detected — ` +
+					`react/jsx-runtime leaked into the bundle (see issue #267).`,
+			)
+		}
+	}
+
+	if (!source.includes('react/jsx-runtime')) {
+		errors.push(
+			`${bundle}: no reference to "react/jsx-runtime" — the JSX runtime is not ` +
+				`externalized as expected (see issue #267).`,
+		)
+	}
+}
+
+if (errors.length > 0) {
+	console.error('✖ Bundle verification failed:')
+	for (const error of errors) console.error(`  - ${error}`)
+	process.exit(1)
+}
+
+console.log(`✔ Bundle verification passed: ${bundles.join(', ')} keep react/jsx-runtime external.`)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
 			fileName: bundleFileName,
 		},
 		rollupOptions: {
-			external: ['react', 'react-dom', 'fuse.js', '@untemps/vocal'],
+			external: [/^react($|\/)/, /^react-dom($|\/)/, 'fuse.js', '@untemps/vocal'],
 		},
 		sourcemap: true,
 	},


### PR DESCRIPTION
## Summary

The Vite library build bundled React's **automatic JSX runtime** (`react/jsx-runtime`) into the published artifacts instead of leaving it external, so every element produced by `Vocal` / `Icon` was created by a build-time copy of **React 19's** jsx factory (`Symbol.for("react.transitional.element")`). This crashed every consumer below React 19 across the declared peer range with *"Objects are not valid as a React child."*

Root cause: Rollup matches string entries in `rollupOptions.external` by **exact module id**, so `'react'` did not cover the `'react/jsx-runtime'` (and `'react/jsx-dev-runtime'`) subpaths injected by `@vitejs/plugin-react`. This PR externalizes those subpaths via regex, adds a build-time guard to prevent regressions, and corrects the declared React floor to match what the externalized runtime actually requires.

## Changes

- **`vite.config.ts`** — `external` now uses `[/^react($|\/)/, /^react-dom($|\/)/, 'fuse.js', '@untemps/vocal']` so `react`, `react-dom` and their subpaths (`jsx-runtime`, `jsx-dev-runtime`, `react-dom/client`, …) stay external. The bundle now emits `import { jsx, jsxs } from "react/jsx-runtime"` (provided by the consumer's React) and no longer inlines `react.transitional.element`.
- **`scripts/verify-bundle.mjs`** (new) + **`postbuild`** / **`verify:bundle`** scripts — a guard that fails the build if either dist bundle inlines a React element symbol (`react.transitional.element` / `react.element`) or stops referencing `react/jsx-runtime`. It derives the bundle paths from `package.json`'s `module`/`main` so it can't drift from the build output. Since CI runs `yarn build`, this protects against a regression of this bug.
- **`package.json` + `README.md`** — raise the React peer floor from `>=16.13.1` to `>=16.14.0`. `react/jsx-runtime` only exists since React 16.14.0; the previous floor was no longer accurate (16.13.x can't resolve the subpath — and was already broken by the inlined-runtime bug this PR fixes, so no working consumer is lost).

## Test plan

- [x] `yarn test:ci` — 203/203 pass
- [x] `yarn build` — bundles emit `import … from "react/jsx-runtime"`; **0** occurrences of `react.transitional.element` in `dist/index.es.js` and `dist/index.cjs`
- [x] `postbuild` guard passes on the real bundle and fails (exit 1) on a deliberately leaked bundle
- [x] `yarn typecheck` and `yarn lint` clean
- [x] Demo (`dev/`) still builds (it consumes `../../src` directly, on React 19)

## ⚠️ Peer-range change
- **`peerDependencies.react` / `react-dom`**: `>=16.13.1` → `>=16.14.0`.
- Migration: none for working consumers. React 16.13.x could not actually use the package (the runtime crash from this bug already affected all React <19); 16.14.0+ and all of 17/18/19 are unaffected. The floor now matches the first React version that ships `react/jsx-runtime`.

Closes #267