### PR TITLE
fix(vocal): Release leaked event handlers when start() rejects or aborts

### DIFF
--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -318,6 +318,7 @@ export const Vocal = ({
 	const startRecognition = useCallback(() => {
 		try {
 			stopSilenceTimer()
+			unsubscribeAllRef.current?.()
 			Object.entries(HANDLERS).forEach(([event, fn]) => subscribe(event, fn as (e: Event) => void))
 			unsubscribeAllRef.current = () =>
 				Object.entries(HANDLERS).forEach(([event, fn]) => unsubscribe(event, fn as (e: Event) => void))

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -1058,6 +1058,153 @@ describe('Vocal', () => {
 		})
 	})
 
+	it('does not double-fire callbacks after a rejected start, and a later session fires once', async () => {
+		const onStart = vi.fn()
+		const onEnd = vi.fn()
+		const onResult = vi.fn()
+		const onError = vi.fn()
+		const recognition = createMockVocal()
+		recognition.stop.mockImplementation(() => {})
+		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onStart, onEnd, onResult, onError }))
+		const baseline = recognition.handlerCount()
+
+		recognition.start.mockRejectedValueOnce(new DOMException('Permission denied', 'NotAllowedError'))
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+			await waitFor(() => expect(onError).toHaveBeenCalledTimes(1))
+		})
+		expect(onError).toHaveBeenCalledWith(expect.objectContaining({ type: 'permission-denied' }))
+		const afterReject = recognition.handlerCount()
+		expect(afterReject).toBeGreaterThan(baseline)
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+			await waitFor(() => expect(onStart).toHaveBeenCalled())
+		})
+		expect(recognition.handlerCount()).toBe(afterReject)
+		await act(async () => {
+			recognition.say('Foo')
+			await waitFor(() => expect(onResult).toHaveBeenCalled())
+		})
+		await act(async () => {
+			recognition.end()
+			await waitFor(() => expect(onEnd).toHaveBeenCalled())
+		})
+
+		expect(onStart).toHaveBeenCalledTimes(1)
+		expect(onResult).toHaveBeenCalledTimes(1)
+		expect(onResult).toHaveBeenCalledWith('Foo', expect.anything())
+		expect(onEnd).toHaveBeenCalledTimes(1)
+		expect(onError).toHaveBeenCalledTimes(1)
+		expect(recognition.handlerCount()).toBe(baseline)
+	})
+
+	it('does not double-fire callbacks after a silent signal-abort that never reaches onError', async () => {
+		const onStart = vi.fn()
+		const onEnd = vi.fn()
+		const onResult = vi.fn()
+		const onError = vi.fn()
+		const recognition = createMockVocal()
+		recognition.stop.mockImplementation(() => {})
+		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onStart, onEnd, onResult, onError }))
+		const baseline = recognition.handlerCount()
+
+		recognition.start.mockImplementationOnce(async () => {})
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+			await new Promise((r) => setTimeout(r, 0))
+		})
+		expect(onStart).not.toHaveBeenCalled()
+		expect(onError).not.toHaveBeenCalled()
+		const afterAbort = recognition.handlerCount()
+		expect(afterAbort).toBeGreaterThan(baseline)
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+			await waitFor(() => expect(onStart).toHaveBeenCalled())
+		})
+		expect(recognition.handlerCount()).toBe(afterAbort)
+		await act(async () => {
+			recognition.say('Bar')
+			await waitFor(() => expect(onResult).toHaveBeenCalled())
+		})
+		await act(async () => {
+			recognition.end()
+			await waitFor(() => expect(onEnd).toHaveBeenCalled())
+		})
+
+		expect(onStart).toHaveBeenCalledTimes(1)
+		expect(onResult).toHaveBeenCalledTimes(1)
+		expect(onResult).toHaveBeenCalledWith('Bar', expect.anything())
+		expect(onEnd).toHaveBeenCalledTimes(1)
+		expect(onError).not.toHaveBeenCalled()
+		expect(recognition.handlerCount()).toBe(baseline)
+	})
+
+	it('still fires onEnd via the trailing end event after an in-session error', async () => {
+		const onEnd = vi.fn()
+		const onError = vi.fn()
+		const recognition = createMockVocal()
+		recognition.stop.mockImplementation(() => {})
+		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onEnd, onError }))
+		const baseline = recognition.handlerCount()
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+			await waitFor(() => expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-pressed', 'true'))
+		})
+
+		await act(async () => {
+			recognition.error({ error: 'network', message: 'Network error' })
+			await waitFor(() => expect(onError).toHaveBeenCalledTimes(1))
+		})
+		expect(onEnd).not.toHaveBeenCalled()
+
+		await act(async () => {
+			recognition.end()
+			await waitFor(() => expect(onEnd).toHaveBeenCalledTimes(1))
+		})
+
+		expect(onError).toHaveBeenCalledTimes(1)
+		expect(onEnd).toHaveBeenCalledTimes(1)
+		expect(recognition.handlerCount()).toBe(baseline)
+	})
+
+	it('delivers the final transcript and onEnd when a continuous session ends via an error', async () => {
+		const onResult = vi.fn()
+		const onEnd = vi.fn()
+		const onError = vi.fn()
+		const recognition = createMockVocal({ continuous: true })
+		recognition.stop.mockImplementation(() => {})
+		const { getByTestId } = render(
+			getInstance({ __rsInstance: recognition, onResult, onEnd, onError, continuous: true, timeout: 10_000 })
+		)
+		const baseline = recognition.handlerCount()
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+			await waitFor(() => expect(getByTestId('__vocal-root__')).toHaveAttribute('aria-pressed', 'true'))
+		})
+		await act(async () => {
+			recognition.say('Hello world')
+		})
+
+		await act(async () => {
+			recognition.error({ error: 'network', message: 'Network error' })
+			await waitFor(() => expect(onError).toHaveBeenCalledTimes(1))
+		})
+		await act(async () => {
+			recognition.fire('result', new Event('result'), 'Hello world', ['Hello world'])
+			recognition.end()
+			await waitFor(() => expect(onEnd).toHaveBeenCalledTimes(1))
+		})
+
+		expect(onResult).toHaveBeenCalledTimes(1)
+		expect(onResult).toHaveBeenCalledWith('Hello world', expect.anything())
+		expect(onEnd).toHaveBeenCalledTimes(1)
+		expect(recognition.handlerCount()).toBe(baseline)
+	})
+
 	describe('Mid-session timing changes', () => {
 		it('honors a null→positive silenceTimeout change mid continuous session (no 0ms timer)', async () => {
 			vi.useFakeTimers()

--- a/src/components/__tests__/createMockVocal.ts
+++ b/src/components/__tests__/createMockVocal.ts
@@ -125,7 +125,8 @@ export const createMockVocal = (options: MockVocalOptions = {}): MockVocalInstan
 		off: vi.fn((type: string, cb?: (...args: unknown[]) => void) => {
 			if (!handlers[type]) return
 			if (cb) {
-				handlers[type] = handlers[type].filter((h) => h !== cb)
+				const index = handlers[type].indexOf(cb)
+				if (index !== -1) handlers[type].splice(index, 1)
 				if (handlers[type].length === 0) delete handlers[type]
 			} else {
 				delete handlers[type]


### PR DESCRIPTION
## Summary

Fixes a handler leak (#268): when `start()` rejects (permission denied) or resolves silently (signal abort), no `end` event fires, so the recognition handlers subscribed by `startRecognition` are never removed. The next `startRecognition` subscribes a second set on top, and every callback (`onStart`, `onResult`, `onEnd`, …) then fires **once per accumulated subscription**.

## Changes

- **`src/components/Vocal.tsx`** — `startRecognition` now defensively releases any prior subscription (`unsubscribeAllRef.current?.()`) before re-subscribing. This heals the leak from either no-`end` terminal path (rejected start or silent abort) on the next start, so a retry re-registers a single set and each callback fires exactly once. Idempotent on a clean start (`@untemps/vocal`'s `off()` no-ops an already-removed handler).
- The teardown is **deliberately not** placed in `_onError`. That callback also runs as the subscribed `error` handler for in-session errors (e.g. `network`), which a real browser always follows with an async `end`. Releasing the subscription there would remove `_onEnd` — and, in continuous mode, the `_onResult` that receives the aggregated transcript vocal emits on `end` — before that trailing `end` arrives, silently dropping `onEnd` and the final transcript.
- **`src/components/__tests__/createMockVocal.ts`** — hardened `off()` to remove a single matching listener per call (`indexOf` + `splice`), mirroring the real `@untemps/vocal` `off()` instead of `filter`-ing out every duplicate at once. This stops the mock from being more forgiving than the library and masking an accumulated leak — the same class of test-mock blind spot called out in the issue.
- **`src/components/__tests__/Vocal.test.tsx`** — 4 regression tests (below).

## Why the existing suite didn't catch it

`createMockVocal.stop()` fires `end` synchronously, so `_onEnd` always ran and cleaned up in tests — the mock was more forgiving than a real browser. The new tests inject an `__rsInstance` whose `stop()` does **not** fire `end`, and the `off()` hardening makes the mock's listener bookkeeping faithful.

## Test plan

- [x] `yarn test:ci` — 207 passing
- [x] `yarn build` + bundle verification, `yarn typecheck`, `yarn lint` — all green
- [x] Demo (`dev/`) builds against the change
- [x] Each new test verified to **fail** when its guarded fix-site is reverted:
  - **Rejected start** / **silent abort** — without the defensive teardown, `onStart` fires twice (verified `expected 1, got 2`).
  - **In-session error** / **continuous in-session error** — re-adding a teardown inside `_onError` drops `onEnd` / the final transcript (verified the trailing `end` no longer reaches the consumer).

## Notes

No public API or behavior change — `onEnd`/`onResult` delivery on in-session errors is preserved; only the leak is fixed. No documentation changes required.

Closes #268