### PR TITLE
feat: Add interimResults prop for live (interim) transcripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ fuse.js is an optional peer dependency — install it separately to enable fuzzy
 | precision       | number            | 0.4                  | Fuse.js score threshold for **phrase** command keys only (lower = stricter). Single-word commands always use exact lookup. |
 | maxAlternatives | number            | 1                    | Maximum number of recognition alternatives per segment. Setting this to 3–5 lets the engine surface the correct word as a secondary transcript, which is useful for handling homophones (e.g. _blue_ / _blew_). |
 | continuous      | boolean           | false                | Keep the recognition session open after each result. The session accumulates transcript across segments and stops when the button is clicked again or `silenceTimeout` expires. Commands are not evaluated in continuous mode. |
+| interimResults  | boolean           | false                | Emit provisional (non-final) transcripts through `onResult` as the user is still speaking, enabling live captions. Each result event carries `event.results[event.resultIndex].isFinal` so consumers can distinguish interim from final text. In non-continuous mode the session is not discarded on an interim result — only the final result ends it (and evaluates commands). |
 | silenceTimeout  | number            | null                 | When `continuous` is true, automatically stop the session after this many ms of silence following the last detected speech (the `speechend` event). `null` or `0` disables auto-stop (button click required). A change during an active session takes effect when the silence timer next re-arms (on the next `speechend`); a countdown already in progress keeps its original deadline, so switching to `null`/`0` does not cancel an auto-stop that is already pending until speech resumes. |
 | style         | object            | null                 | Styles of the root element if className is not specified                                        |
 | className     | string            | null                 | Class of the root element                                                                       |
@@ -361,7 +362,7 @@ const App = () => {
 #### Signature
 
 ```
-useVocal(lang, grammars, maxAlternatives, continuous)
+useVocal(lang, grammars, maxAlternatives, continuous, interimResults)
 ```
 
 | Args            | Type              | Default | Description                                                                                     |
@@ -370,6 +371,7 @@ useVocal(lang, grammars, maxAlternatives, continuous)
 | grammars        | SpeechGrammarList | null    | Grammars understood by the recognition [JSpeech Grammar Format](https://www.w3.org/TR/jsgf/)    |
 | maxAlternatives | number            | 1       | Maximum number of recognition alternatives per segment                                          |
 | continuous      | boolean           | false   | Keep the recognition session open after each result                                             |
+| interimResults  | boolean           | false   | Emit provisional (non-final) transcripts as the user is still speaking (live captions)          |
 
 > :warning: **Memoize non-primitive arguments.** `useVocal` rebuilds its recognition instance whenever an argument changes identity. `grammars` is non-primitive, so passing a fresh value each render — `useVocal(lang, new SpeechGrammarList())` — triggers a teardown/rebuild cycle on every render. Wrap such arguments in `useMemo` to keep their identity stable across renders.
 

--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -93,6 +93,7 @@ export interface VocalProps {
 	precision?: number
 	maxAlternatives?: number
 	continuous?: boolean
+	interimResults?: boolean
 	ariaLabel?: string
 	style?: CSSProperties | null
 	className?: string | null
@@ -132,6 +133,7 @@ export const Vocal = ({
 	precision = 0.4, // Fuse.js score threshold for phrase commands only; single-word commands always use exact lookup
 	maxAlternatives = 1,
 	continuous = false,
+	interimResults = false,
 	ariaLabel = 'start recognition',
 	style = null,
 	className = null,
@@ -153,7 +155,8 @@ export const Vocal = ({
 		lang,
 		grammars,
 		maxAlternatives,
-		continuous
+		continuous,
+		interimResults
 	)
 	const triggerCommand = useCommands(commands, precision)
 
@@ -248,12 +251,15 @@ export const Vocal = ({
 			// Continuous mode: vocal 2.x emits one aggregated synthetic event before 'end'; commands are
 			// intentionally not matched against the full session transcript
 			if (!continuousRef.current) {
-				const results =
-					(event as SpeechRecognitionEvent).results !== undefined
-						? Array.from((event as SpeechRecognitionEvent).results, (segment) => Array.from(segment))
-						: []
-				tryMatchCommand(results, triggerCommandRef.current)
-				stopRecognition()
+				const srEvent = event as SpeechRecognitionEvent
+				const segment = srEvent.results?.[srEvent.resultIndex ?? 0]
+				const isFinal = segment ? segment.isFinal !== false : true
+				if (isFinal) {
+					const results =
+						srEvent.results !== undefined ? Array.from(srEvent.results, (seg) => Array.from(seg)) : []
+					tryMatchCommand(results, triggerCommandRef.current)
+					stopRecognition()
+				}
 			}
 			propsRef.current.onResult?.(bestAlternative, event)
 		},

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -365,6 +365,41 @@ describe('Vocal', () => {
 		})
 	})
 
+	it('forwards interimResults to the vocal factory', () => {
+		render(getInstance({ interimResults: true }))
+		expect(createVocal).toHaveBeenCalledWith(expect.objectContaining({ interimResults: true }))
+	})
+
+	it('streams interim results to onResult without ending the session, then stops on the final result', async () => {
+		const buildResult = (transcript: string, isFinal: boolean) =>
+			Object.assign(new Event('result'), {
+				resultIndex: 0,
+				results: [Object.assign([{ transcript }], { isFinal })],
+			})
+		const onResult = vi.fn()
+		const onEnd = vi.fn()
+		const recognition = createMockVocal()
+		const { getByTestId } = render(getInstance({ __rsInstance: recognition, onResult, onEnd }))
+
+		await act(async () => {
+			fireEvent.click(getByTestId('__vocal-root__'))
+		})
+
+		await act(async () => {
+			recognition.fire('result', buildResult('Fo', false), 'Fo', ['Fo'])
+		})
+		expect(onResult).toHaveBeenCalledWith('Fo', expect.anything())
+		expect(recognition.stop).not.toHaveBeenCalled()
+		expect(onEnd).not.toHaveBeenCalled()
+
+		await act(async () => {
+			recognition.fire('result', buildResult('Foo', true), 'Foo', ['Foo'])
+			await waitFor(() => expect(onEnd).toHaveBeenCalled())
+		})
+		expect(onResult).toHaveBeenLastCalledWith('Foo', expect.anything())
+		expect(recognition.stop).toHaveBeenCalled()
+	})
+
 	it('triggers onNoMatch handler', async () => {
 		const onNoMatch = vi.fn()
 		const recognition = createMockVocal()

--- a/src/hooks/__tests__/useVocal.test.ts
+++ b/src/hooks/__tests__/useVocal.test.ts
@@ -139,7 +139,33 @@ describe('useVocal', () => {
 				grammars: null,
 				maxAlternatives: 5,
 				continuous: false,
+				interimResults: false,
 			})
+		})
+
+		it('defaults interimResults to false', () => {
+			renderHook(() => useVocal())
+			expect(createVocal).toHaveBeenCalledWith(expect.objectContaining({ interimResults: false }))
+		})
+
+		it('passes interimResults to createVocal factory', () => {
+			renderHook(() => useVocal('en-US', null, 1, false, true))
+			expect(createVocal).toHaveBeenCalledWith(expect.objectContaining({ interimResults: true }))
+		})
+
+		it('tears down and recreates the instance when interimResults changes', () => {
+			const { rerender } = renderHook(({ interimResults }) => useVocal('en-US', null, 1, false, interimResults), {
+				initialProps: { interimResults: false },
+			})
+			expect(createVocal).toHaveBeenCalledTimes(1)
+			expect(createVocal).toHaveBeenLastCalledWith(expect.objectContaining({ interimResults: false }))
+
+			rerender({ interimResults: true })
+
+			expect(createVocal).toHaveBeenCalledTimes(2)
+			expect(createVocal).toHaveBeenLastCalledWith(expect.objectContaining({ interimResults: true }))
+			expect(mockAbort).toHaveBeenCalledTimes(1)
+			expect(mockCleanup).toHaveBeenCalledTimes(1)
 		})
 
 		it('triggers start function', () => {

--- a/src/hooks/useVocal.ts
+++ b/src/hooks/useVocal.ts
@@ -31,7 +31,8 @@ export const useVocal = (
 	lang: string = 'en-US',
 	grammars: SpeechGrammarList | null = null,
 	maxAlternatives: number = 1,
-	continuous: boolean = false
+	continuous: boolean = false,
+	interimResults: boolean = false
 ): UseVocalReturn => {
 	const ref = useRef<VocalInstance | null>(null)
 	const [isRecording, setIsRecording] = useState(false)
@@ -40,7 +41,7 @@ export const useVocal = (
 
 	useEffect(() => {
 		if (supported) {
-			const instance = createVocal({ lang, grammars, maxAlternatives, continuous })
+			const instance = createVocal({ lang, grammars, maxAlternatives, continuous, interimResults })
 			ref.current = instance
 
 			const handleStart = () => setIsRecording(true)
@@ -63,7 +64,7 @@ export const useVocal = (
 				setPermissionState(null)
 			}
 		}
-	}, [lang, grammars, maxAlternatives, continuous, supported])
+	}, [lang, grammars, maxAlternatives, continuous, interimResults, supported])
 
 	const start = useCallback(async (options?: { signal?: AbortSignal }): Promise<void> => {
 		const instance = ref.current


### PR DESCRIPTION
## What

Thread the Web Speech API's `interimResults` flag through `useVocal` and the `<Vocal>` component so consumers can render **live captions** as the user is still speaking.

- New `<Vocal interimResults>` prop (default `false`) and 5th argument `useVocal(lang, grammars, maxAlternatives, continuous, interimResults)`, forwarded to `createVocal` (already supported by `@untemps/vocal@2.2.0`).
- In **non-continuous** mode, `_onResult` now finalizes (matches commands and stops the session) only on the **final** segment, gated on `SpeechRecognitionResult.isFinal`. An interim result no longer truncates the session.
- Backward-compatible: absent `isFinal` (interimResults off, or synthetic aggregated events) still counts as final, so existing behavior is unchanged.

## Why

Live/interim transcripts are the most compelling thing to show for speech recognition, and the demo revamp (stacked PR) uses this for its dictation card. Without it, `interimResults` couldn't reach `createVocal`.

## Tests

- New coverage in `useVocal.test.ts` (factory forwarding, teardown/recreate on change) and `Vocal.test.tsx` (interim streams to `onResult` without ending; final ends + matches).
- 212 tests pass, branches coverage 93.8% (threshold 85%), typecheck + build + bundle verification green.
- README updated (both the `<Vocal>` props table and the `useVocal` signature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)