### PR TITLE
fix(useVocal): isRecording flicker/double-start race and stale subscriptions after instance recreation

### DIFF
--- a/src/hooks/__tests__/useVocal.test.ts
+++ b/src/hooks/__tests__/useVocal.test.ts
@@ -89,8 +89,6 @@ describe('useVocal', () => {
 	})
 
 	describe('with SpeechRecognition support', () => {
-		// Mirrors vocal 2.x: isRecording flips true synchronously on a genuine start and
-		// stays false on a silent abort. Tests opt out via mockStart to simulate aborts.
 		let mockIsRecording = false
 
 		beforeAll(() => {
@@ -107,8 +105,6 @@ describe('useVocal', () => {
 			mockOff.mockReset()
 			mockCleanup.mockReset()
 			mockIsRecording = false
-			// Default to vocal's genuine-start contract: start() resolves and the instance
-			// reports isRecording === true. Silent-abort tests override this below.
 			mockStart.mockImplementation(async () => {
 				mockIsRecording = true
 			})
@@ -264,8 +260,6 @@ describe('useVocal', () => {
 		})
 
 		it('keeps isRecording true when start() resolves and recognition actually started', async () => {
-			// Regression guard: the reconciliation must not roll back a genuine start, where the
-			// instance reports isRecording === true even though 'start' dispatches asynchronously.
 			const controller = new AbortController()
 			const { result } = renderHook(() => useVocal())
 			await act(async () => {
@@ -275,8 +269,6 @@ describe('useVocal', () => {
 		})
 
 		it('keeps isRecording true when recognition started even if the signal aborts late', async () => {
-			// Race: recognition truly started (instance.isRecording === true), then the consumer
-			// aborts. Reconciliation reads the instance's own state, so the late abort is a no-op.
 			const controller = new AbortController()
 			const { result } = renderHook(() => useVocal())
 			await act(async () => {
@@ -471,8 +463,6 @@ describe('useVocal', () => {
 
 			rerender({ lang: 'fr-FR' })
 
-			// The disposed instance detached the handler and the new instance re-attached it,
-			// so a subscribe() made before the switch keeps receiving events afterwards.
 			expect(mockOff).toHaveBeenCalledWith('result', handler)
 			const resultOnsAfter = mockOn.mock.calls.filter(([type]) => type === 'result').length
 			expect(resultOnsAfter).toBe(resultOnsBefore + 1)
@@ -489,7 +479,6 @@ describe('useVocal', () => {
 
 			rerender({ lang: 'fr-FR' })
 
-			// Unsubscribed handlers leave the registry, so the recreated instance does not re-attach them.
 			const resultOnsAfter = mockOn.mock.calls.filter(([type]) => type === 'result').length
 			expect(resultOnsAfter).toBe(resultOnsBefore)
 		})

--- a/src/hooks/__tests__/useVocal.test.ts
+++ b/src/hooks/__tests__/useVocal.test.ts
@@ -459,5 +459,39 @@ describe('useVocal', () => {
 			expect(mockAbort).toHaveBeenCalledTimes(1)
 			expect(mockCleanup).toHaveBeenCalledTimes(1)
 		})
+
+		it('re-attaches consumer subscriptions to the recreated instance when lang changes', () => {
+			const handler = vi.fn()
+			const { result, rerender } = renderHook(({ lang }) => useVocal(lang), {
+				initialProps: { lang: 'en-US' },
+			})
+			result.current[1].subscribe('result', handler)
+			expect(mockOn).toHaveBeenCalledWith('result', handler)
+			const resultOnsBefore = mockOn.mock.calls.filter(([type]) => type === 'result').length
+
+			rerender({ lang: 'fr-FR' })
+
+			// The disposed instance detached the handler and the new instance re-attached it,
+			// so a subscribe() made before the switch keeps receiving events afterwards.
+			expect(mockOff).toHaveBeenCalledWith('result', handler)
+			const resultOnsAfter = mockOn.mock.calls.filter(([type]) => type === 'result').length
+			expect(resultOnsAfter).toBe(resultOnsBefore + 1)
+		})
+
+		it('stops re-attaching a subscription after it is unsubscribed', () => {
+			const handler = vi.fn()
+			const { result, rerender } = renderHook(({ lang }) => useVocal(lang), {
+				initialProps: { lang: 'en-US' },
+			})
+			result.current[1].subscribe('result', handler)
+			result.current[1].unsubscribe('result', handler)
+			const resultOnsBefore = mockOn.mock.calls.filter(([type]) => type === 'result').length
+
+			rerender({ lang: 'fr-FR' })
+
+			// Unsubscribed handlers leave the registry, so the recreated instance does not re-attach them.
+			const resultOnsAfter = mockOn.mock.calls.filter(([type]) => type === 'result').length
+			expect(resultOnsAfter).toBe(resultOnsBefore)
+		})
 	})
 })

--- a/src/hooks/__tests__/useVocal.test.ts
+++ b/src/hooks/__tests__/useVocal.test.ts
@@ -89,6 +89,10 @@ describe('useVocal', () => {
 	})
 
 	describe('with SpeechRecognition support', () => {
+		// Mirrors vocal 2.x: isRecording flips true synchronously on a genuine start and
+		// stays false on a silent abort. Tests opt out via mockStart to simulate aborts.
+		let mockIsRecording = false
+
 		beforeAll(() => {
 			vi.mocked(isSupported).mockReturnValue(true)
 		})
@@ -102,9 +106,12 @@ describe('useVocal', () => {
 			mockOn.mockReset()
 			mockOff.mockReset()
 			mockCleanup.mockReset()
-			// vocal 2.x's start() always returns a Promise — default the mock to
-			// match the real contract so tests don't have to opt in every time.
-			mockStart.mockReturnValue(Promise.resolve())
+			mockIsRecording = false
+			// Default to vocal's genuine-start contract: start() resolves and the instance
+			// reports isRecording === true. Silent-abort tests override this below.
+			mockStart.mockImplementation(async () => {
+				mockIsRecording = true
+			})
 			vi.mocked(createVocal).mockImplementation(() => ({
 				start: mockStart,
 				stop: mockStop,
@@ -113,7 +120,7 @@ describe('useVocal', () => {
 				off: mockOff,
 				cleanup: mockCleanup,
 				get isRecording() {
-					return false
+					return mockIsRecording
 				},
 			}))
 		})
@@ -256,14 +263,9 @@ describe('useVocal', () => {
 			expect(result.current[1].isRecording).toBe(false)
 		})
 
-		it('keeps isRecording true when start() resolves and the signal is not aborted', async () => {
-			// Regression guard: the silent-resolve rollback must not fire on a normal start.
-			// Simulate vocal's contract by dispatching 'start' before resolving.
-			mockStart.mockImplementation(async () => {
-				mockOn.mock.calls
-					.filter(([type]) => type === 'start')
-					.forEach(([, handler]) => (handler as () => void)())
-			})
+		it('keeps isRecording true when start() resolves and recognition actually started', async () => {
+			// Regression guard: the reconciliation must not roll back a genuine start, where the
+			// instance reports isRecording === true even though 'start' dispatches asynchronously.
 			const controller = new AbortController()
 			const { result } = renderHook(() => useVocal())
 			await act(async () => {
@@ -272,40 +274,17 @@ describe('useVocal', () => {
 			expect(result.current[1].isRecording).toBe(true)
 		})
 
-		it('keeps isRecording true when the start event fires and the signal aborts late', async () => {
-			// Race: 'start' already fired, then the consumer aborts before the wrapper's .then microtask.
-			// Rollback must check whether 'start' fired, not signal.aborted, so isRecording stays true.
-			let resolveStart: (() => void) | undefined
-			mockStart.mockReturnValue(
-				new Promise<void>((res) => {
-					resolveStart = res
-				})
-			)
+		it('keeps isRecording true when recognition started even if the signal aborts late', async () => {
+			// Race: recognition truly started (instance.isRecording === true), then the consumer
+			// aborts. Reconciliation reads the instance's own state, so the late abort is a no-op.
 			const controller = new AbortController()
 			const { result } = renderHook(() => useVocal())
 			await act(async () => {
 				const p = result.current[1].start({ signal: controller.signal })
-				// Simulate vocal dispatching 'start' to subscribers, including the wrapper's tracker.
-				mockOn.mock.calls
-					.filter(([type]) => type === 'start')
-					.forEach(([, handler]) => (handler as () => void)())
-				// Consumer aborts after recognition truly started.
 				controller.abort()
-				resolveStart?.()
 				await p
 			})
 			expect(result.current[1].isRecording).toBe(true)
-		})
-
-		it('unsubscribes the internal start tracker once the promise settles', async () => {
-			// The transient 'start' listener (for silent-abort detection) must be removed
-			// once the promise settles, else repeated calls leak listeners on the instance.
-			mockStart.mockReturnValue(Promise.resolve())
-			const { result } = renderHook(() => useVocal())
-			await act(async () => {
-				await result.current[1].start()
-			})
-			expect(mockOff).toHaveBeenCalledWith('start', expect.any(Function))
 		})
 
 		it('triggers stop function', () => {
@@ -409,12 +388,6 @@ describe('useVocal', () => {
 		})
 
 		it('optimistically flips isRecording to true when start() is called', async () => {
-			// Simulate vocal's real contract: 'start' fires before start() resolves.
-			mockStart.mockImplementation(async () => {
-				mockOn.mock.calls
-					.filter(([type]) => type === 'start')
-					.forEach(([, handler]) => (handler as () => void)())
-			})
 			const { result } = renderHook(() => useVocal())
 			await act(async () => result.current[1].start())
 			expect(result.current[1].isRecording).toBe(true)

--- a/src/hooks/useVocal.ts
+++ b/src/hooks/useVocal.ts
@@ -35,6 +35,10 @@ export const useVocal = (
 	interimResults: boolean = false
 ): UseVocalReturn => {
 	const ref = useRef<VocalInstance | null>(null)
+	// Consumer subscriptions, tracked so they can be re-attached whenever the instance is
+	// recreated on a lang/option change — consumers subscribe once and their listeners
+	// follow the live instance instead of stranding on the disposed one.
+	const subscriptionsRef = useRef<Array<[EventType | string, EventHandlerFor<EventType> | GenericEventHandler]>>([])
 	const [isRecording, setIsRecording] = useState(false)
 	const [permissionState, setPermissionState] = useState<PermissionState | null>(null)
 	const supported = useMemo(() => isSupported(), [])
@@ -53,11 +57,18 @@ export const useVocal = (
 			const handlePermission: EventHandlerFor<'permission'> = (_event, state) => setPermissionState(state)
 			instance.on('permission', handlePermission)
 
+			for (const [eventType, handler] of subscriptionsRef.current) {
+				instance.on(eventType as EventType, handler as EventHandlerFor<EventType>)
+			}
+
 			return () => {
 				instance.off('start', handleStart)
 				instance.off('end', handleStop)
 				instance.off('error', handleStop)
 				instance.off('permission', handlePermission)
+				for (const [eventType, handler] of subscriptionsRef.current) {
+					instance.off(eventType as EventType, handler as EventHandlerFor<EventType>)
+				}
 				instance.abort()
 				instance.cleanup()
 				setIsRecording(false)
@@ -99,18 +110,18 @@ export const useVocal = (
 
 	const subscribe = useCallback(
 		(eventType: EventType | string, handler: EventHandlerFor<EventType> | GenericEventHandler) => {
-			if (ref.current) {
-				ref.current.on(eventType as EventType, handler as EventHandlerFor<EventType>)
-			}
+			subscriptionsRef.current.push([eventType, handler])
+			ref.current?.on(eventType as EventType, handler as EventHandlerFor<EventType>)
 		},
 		[]
 	) as UseVocalActions['subscribe']
 
 	const unsubscribe = useCallback(
 		(eventType: EventType | string, handler?: EventHandlerFor<EventType> | GenericEventHandler) => {
-			if (ref.current) {
-				ref.current.off(eventType as EventType, handler as EventHandlerFor<EventType>)
-			}
+			subscriptionsRef.current = subscriptionsRef.current.filter(
+				([type, registered]) => !(type === eventType && (handler === undefined || registered === handler))
+			)
+			ref.current?.off(eventType as EventType, handler as EventHandlerFor<EventType>)
 		},
 		[]
 	) as UseVocalActions['unsubscribe']

--- a/src/hooks/useVocal.ts
+++ b/src/hooks/useVocal.ts
@@ -35,9 +35,6 @@ export const useVocal = (
 	interimResults: boolean = false
 ): UseVocalReturn => {
 	const ref = useRef<VocalInstance | null>(null)
-	// Consumer subscriptions, tracked so they can be re-attached whenever the instance is
-	// recreated on a lang/option change — consumers subscribe once and their listeners
-	// follow the live instance instead of stranding on the disposed one.
 	const subscriptionsRef = useRef<Array<[EventType | string, EventHandlerFor<EventType> | GenericEventHandler]>>([])
 	const [isRecording, setIsRecording] = useState(false)
 	const [permissionState, setPermissionState] = useState<PermissionState | null>(null)
@@ -80,15 +77,9 @@ export const useVocal = (
 	const start = useCallback(async (options?: { signal?: AbortSignal }): Promise<void> => {
 		const instance = ref.current
 		if (!instance) return
-		// Optimistic update so the UI reacts immediately at click, before the
-		// async permission/getUserMedia chain resolves.
 		setIsRecording(true)
 		try {
 			await instance.start(options)
-			// vocal flips its own isRecording synchronously once recognition starts, but only
-			// dispatches 'start' asynchronously — and it may resolve start() without ever
-			// starting (aborted signal / swallowed AbortError). Reconcile against the
-			// instance's own state rather than the not-yet-fired event.
 			if (!instance.isRecording) setIsRecording(false)
 		} catch (err) {
 			setIsRecording(false)
@@ -110,20 +101,22 @@ export const useVocal = (
 
 	const subscribe = useCallback(
 		(eventType: EventType | string, handler: EventHandlerFor<EventType> | GenericEventHandler) => {
+			if (!supported) return
 			subscriptionsRef.current.push([eventType, handler])
 			ref.current?.on(eventType as EventType, handler as EventHandlerFor<EventType>)
 		},
-		[]
+		[supported]
 	) as UseVocalActions['subscribe']
 
 	const unsubscribe = useCallback(
 		(eventType: EventType | string, handler?: EventHandlerFor<EventType> | GenericEventHandler) => {
+			if (!supported) return
 			subscriptionsRef.current = subscriptionsRef.current.filter(
 				([type, registered]) => !(type === eventType && (handler === undefined || registered === handler))
 			)
 			ref.current?.off(eventType as EventType, handler as EventHandlerFor<EventType>)
 		},
-		[]
+		[supported]
 	) as UseVocalActions['unsubscribe']
 
 	const clean = useCallback(() => {

--- a/src/hooks/useVocal.ts
+++ b/src/hooks/useVocal.ts
@@ -70,24 +70,18 @@ export const useVocal = (
 		const instance = ref.current
 		if (!instance) return
 		// Optimistic update so the UI reacts immediately at click, before the
-		// async permission/getUserMedia chain resolves and fires the 'start' event.
+		// async permission/getUserMedia chain resolves.
 		setIsRecording(true)
-		// vocal 2.x's start() may resolve without ever firing 'start' (e.g. a swallowed
-		// AbortError), leaving the optimistic flag stuck on `true`. Roll back only when the
-		// real 'start' event never fired, so a late abort racing a genuine success is safe.
-		let startEventFired = false
-		const onStart = () => {
-			startEventFired = true
-		}
-		instance.on('start', onStart)
 		try {
 			await instance.start(options)
-			if (!startEventFired) setIsRecording(false)
+			// vocal flips its own isRecording synchronously once recognition starts, but only
+			// dispatches 'start' asynchronously — and it may resolve start() without ever
+			// starting (aborted signal / swallowed AbortError). Reconcile against the
+			// instance's own state rather than the not-yet-fired event.
+			if (!instance.isRecording) setIsRecording(false)
 		} catch (err) {
 			setIsRecording(false)
 			throw err
-		} finally {
-			instance.off('start', onStart)
 		}
 	}, [])
 


### PR DESCRIPTION
Two `useVocal` correctness bugs surfaced while reviewing the demo revamp. Both are independent of the demo and belong on the library; extracted here onto `beta`.

## Bug 1 — optimistic `isRecording` never reconciles correctly (flicker + double-start window)

`start()` set an optimistic `isRecording = true`, then tried to roll it back only when a transient `'start'` listener had **not** fired — checked synchronously right after `await instance.start()`.

But `@untemps/vocal` dispatches `'start'` **asynchronously, after** `start()` resolves (it calls the native `recognition.start()` and resolves immediately; the browser fires `'start'` in a later task). So at the check the flag was always still `false`, and **every successful start** committed a `true → false → true` render sequence:

- a visible mic-icon / `aria-pressed` flicker, and
- a brief window where the button re-enables (`disabled={… || isRecording}`) and its `onClick` points back at `start`, so a fast second click double-starts recognition — native `start()` then throws `InvalidStateError`.

**Fix:** reconcile against `instance.isRecording`, which vocal sets synchronously on a genuine start and leaves `false` on an aborted signal / swallowed `AbortError`. This drops the transient listener entirely and is correct regardless of when `'start'` fires.

The `useVocal` test mock hardcoded `isRecording: false` and dispatched `'start'` *during* `start()` — an unrealistic model that hid the bug. It now mirrors vocal's real contract (`isRecording` flips true synchronously on a genuine start; silent-abort tests opt out).

## Bug 2 — subscriptions stranded on the disposed instance after a recreation

`useVocal` recreates its vocal instance when `lang` / `grammars` / `maxAlternatives` / `continuous` / `interimResults` change, but `subscribe` / `unsubscribe` are stable callbacks. A consumer effect keyed on `[subscribe, unsubscribe]` never re-runs, so its listeners stay bound to the aborted instance and the **new** instance receives none — e.g. an event log goes silent after a language switch.

**Fix:** track consumer subscriptions in a registry and re-attach them to each recreated instance (and detach them from the disposed one). Consumers subscribe once and their listeners follow the live instance — no per-consumer workaround needed.

## Validation

- `yarn test:ci` — 213 passing, coverage above thresholds (99.16 / 93.75 / 100 / 99.68)
- `yarn typecheck`, `yarn lint`, `yarn build` + `verify-bundle` all green

Scope: `src/hooks/useVocal.ts` and its test only. No public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
