### PR TITLE
feat: Support custom speech engines and add a Gladia demo card

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,10 @@ This removes the Rollup `MIXED_EXPORTS` warning from the build and aligns the ES
 - `useCommands` shapes (`CommandCallback`, `CommandsMap`, `TriggerCommand`)
 - Error classification (`VocalError`, `VocalErrorType`, `classifyError`)
 - `isSupported` function (re-exported from `@untemps/vocal`)
+- Custom speech engines (`createEngine`, `WebSpeechEngine`, `SpeechEngineFactory`, `SpeechEngineInstance`, `SpeechEngineContext`, `CreateVocalOptions`, `EngineBackend`, `EngineConnectContext`, `EngineSession`) — re-exported from `@untemps/vocal`; see [Custom speech engines](#custom-speech-engines)
 
 ```typescript
-import { Vocal, useVocal, isSupported, type VocalProps, type CommandsMap } from '@untemps/react-vocal'
+import { Vocal, useVocal, isSupported, createEngine, type VocalProps, type CommandsMap } from '@untemps/react-vocal'
 ```
 
 TypeScript is listed as an optional peer dependency (`>=6.0.0`) — install it only if your project uses TS.
@@ -279,6 +280,7 @@ fuse.js is an optional peer dependency — install it separately to enable fuzzy
 | maxAlternatives | number            | 1                    | Maximum number of recognition alternatives per segment. Setting this to 3–5 lets the engine surface the correct word as a secondary transcript, which is useful for handling homophones (e.g. _blue_ / _blew_). |
 | continuous      | boolean           | false                | Keep the recognition session open after each result. The session accumulates transcript across segments and stops when the button is clicked again or `silenceTimeout` expires. Commands are not evaluated in continuous mode. |
 | interimResults  | boolean           | false                | Emit provisional (non-final) transcripts through `onResult` as the user is still speaking, enabling live captions. Each result event carries `event.results[event.resultIndex].isFinal` so consumers can distinguish interim from final text. In non-continuous mode the session is not discarded on an interim result — only the final result ends it (and evaluates commands). |
+| engine          | SpeechEngineFactory | undefined           | Custom speech recognition backend (a `SpeechEngineFactory`, typically built with `createEngine`). When omitted, the built-in Web Speech API engine is used. Lets you drive a cloud/on-device STT service and brings recognition to browsers without `SpeechRecognition`. See [Custom speech engines](#custom-speech-engines). **Memoize it** — a fresh factory identity tears down and rebuilds the recognition instance. |
 | silenceTimeout  | number            | null                 | When `continuous` is true, automatically stop the session after this many ms of silence following the last detected speech (the `speechend` event). `null` or `0` disables auto-stop (button click required). A change during an active session takes effect when the silence timer next re-arms (on the next `speechend`); a countdown already in progress keeps its original deadline, so switching to `null`/`0` does not cancel an auto-stop that is already pending until speech resumes. |
 | style         | object            | null                 | Styles of the root element if className is not specified                                        |
 | className     | string            | null                 | Class of the root element                                                                       |
@@ -362,7 +364,7 @@ const App = () => {
 #### Signature
 
 ```
-useVocal(lang, grammars, maxAlternatives, continuous, interimResults)
+useVocal(lang, grammars, maxAlternatives, continuous, interimResults, engine)
 ```
 
 | Args            | Type              | Default | Description                                                                                     |
@@ -372,8 +374,9 @@ useVocal(lang, grammars, maxAlternatives, continuous, interimResults)
 | maxAlternatives | number            | 1       | Maximum number of recognition alternatives per segment                                          |
 | continuous      | boolean           | false   | Keep the recognition session open after each result                                             |
 | interimResults  | boolean           | false   | Emit provisional (non-final) transcripts as the user is still speaking (live captions)          |
+| engine          | SpeechEngineFactory | undefined | Custom recognition backend (a `SpeechEngineFactory`). Omit to use the built-in Web Speech engine. See [Custom speech engines](#custom-speech-engines). |
 
-> :warning: **Memoize non-primitive arguments.** `useVocal` rebuilds its recognition instance whenever an argument changes identity. `grammars` is non-primitive, so passing a fresh value each render — `useVocal(lang, new SpeechGrammarList())` — triggers a teardown/rebuild cycle on every render. Wrap such arguments in `useMemo` to keep their identity stable across renders.
+> :warning: **Memoize non-primitive arguments.** `useVocal` rebuilds its recognition instance whenever an argument changes identity. `grammars` and `engine` are non-primitive, so passing a fresh value each render — `useVocal(lang, new SpeechGrammarList())` or `useVocal(lang, null, 1, false, false, createGladiaEngine({ apiKey }))` — triggers a teardown/rebuild cycle on every render. Wrap such arguments in `useMemo` to keep their identity stable across renders.
 
 ---
 
@@ -476,6 +479,73 @@ const App = () => {
 	return isSupported() ? <Vocal /> : <p>Your browser does not support Web Speech API</p>
 }
 ```
+
+Pass a [custom engine](#custom-speech-engines) factory to probe **that** backend instead of the Web Speech API — useful when you ship a cloud or on-device engine to browsers where `SpeechRecognition` is missing:
+
+```javascript
+import { isSupported } from '@untemps/react-vocal'
+import { createGladiaEngine } from './gladiaEngine'
+
+const engine = createGladiaEngine({ apiKey })
+isSupported(engine) // probes the engine's own support (microphone + transport) instead of SpeechRecognition
+```
+
+### Custom speech engines
+
+By default `Vocal` and `useVocal` drive the browser's Web Speech API. Pass an `engine` — any `SpeechEngineFactory` — to target a different backend instead: a cloud STT service (Gladia, Deepgram, OpenAI…) or an on-device model. Because a custom engine does not rely on `SpeechRecognition`, it also brings speech recognition to browsers that lack it (e.g. Firefox). Omitting `engine` keeps the built-in Web Speech engine, so existing code is unaffected.
+
+```tsx
+import { Vocal, createEngine } from '@untemps/react-vocal'
+
+const engine = createEngine({
+	isSupported: () => typeof WebSocket !== 'undefined',
+	async connect({ stream, signal, language, options, emitTranscript, emitError, end }) {
+		// Stream `stream` to your backend, then push transcripts back to Vocal:
+		//   emitTranscript(text, { isFinal }) → the base applies the interim/continuous policy
+		//   emitError(message)                → emits a well-formed `error` event
+		//   end({ flush: true })              → flush the aggregated transcript and emit `end`
+		return {
+			stop() {
+				/* graceful close; call end({ flush: true }) once the transport drains */
+			},
+			abort() {
+				/* immediate teardown of the transport and the stream */
+			},
+		}
+	},
+})
+
+const App = () => <Vocal engine={engine} lang="en-US" interimResults onResult={(text) => console.log(text)} />
+```
+
+The engine authoring surface is re-exported from `@untemps/vocal`, so you can build one without adding a second dependency:
+
+| Export            | Kind     | Description                                                                                                                                                                                                                 |
+| ----------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `createEngine`    | function | Scaffolds a `SpeechEngineFactory` from a small backend (`isSupported?` + `connect`). It owns microphone acquisition, `AbortSignal` handling, the `fr-FR → fr` language reduction, transcript aggregation in continuous mode, and the `start`/`result`/`end`/`error` lifecycle — your backend implements only its transport. |
+| `WebSpeechEngine` | function | The built-in Web Speech engine factory — the default backend used when no `engine` is passed.                                                                                                                              |
+| _types_           | types    | `SpeechEngineFactory`, `SpeechEngineInstance`, `SpeechEngineContext`, `CreateVocalOptions`, `EngineBackend`, `EngineConnectContext`, `EngineSession` for engine authors.                                                    |
+
+> :warning: **Memoize the engine.** Like `grammars`, a fresh factory identity on every render tears down and rebuilds the recognition instance. Wrap it in `useMemo` keyed on its inputs (e.g. the API key).
+
+See the [`@untemps/vocal` custom-engine guide](https://github.com/untemps/vocal#custom-speech-engines) for the full contract and additional reference backends.
+
+#### Example: a Gladia cloud engine
+
+The [demo](./dev) wires a real [Gladia](https://gladia.io) engine behind this seam — it streams PCM16 audio to Gladia over a WebSocket (an `AudioWorklet` converts Float32 → PCM16 off the main thread) and maps Gladia's partial/final transcripts onto `onResult`:
+
+```tsx
+import { useMemo } from 'react'
+import { Vocal } from '@untemps/react-vocal'
+import { createGladiaEngine } from './gladiaEngine' // demo engine — see dev/src/lib/gladiaEngine.ts
+
+const GladiaMic = ({ apiKey, lang }: { apiKey: string; lang: string }) => {
+	const engine = useMemo(() => createGladiaEngine({ apiKey }), [apiKey])
+	return <Vocal engine={engine} lang={lang} continuous interimResults onResult={(text) => console.log(text)} />
+}
+```
+
+Run `yarn dev` and open the **Custom engine — Gladia** card to try it (bring your own [Gladia](https://gladia.io) API key). The key stays in the browser and is proxied through Vite for local convenience — in production, mint short-lived credentials server-side and never ship a raw key to the client.
 
 ### Events
 

--- a/dev/public/pcm-worklet.js
+++ b/dev/public/pcm-worklet.js
@@ -1,0 +1,34 @@
+const TARGET_SAMPLES = 1600
+
+class PCMProcessor extends AudioWorkletProcessor {
+	constructor() {
+		super()
+		this._chunks = []
+		this._count = 0
+	}
+
+	process(inputs) {
+		const channel = inputs[0]?.[0]
+		if (channel) {
+			this._chunks.push(channel.slice(0))
+			this._count += channel.length
+
+			if (this._count >= TARGET_SAMPLES) {
+				const pcm = new Int16Array(this._count)
+				let offset = 0
+				for (const chunk of this._chunks) {
+					for (let i = 0; i < chunk.length; i++) {
+						const s = Math.max(-1, Math.min(1, chunk[i]))
+						pcm[offset++] = s < 0 ? s * 0x8000 : s * 0x7fff
+					}
+				}
+				this.port.postMessage(pcm.buffer, [pcm.buffer])
+				this._chunks = []
+				this._count = 0
+			}
+		}
+		return true
+	}
+}
+
+registerProcessor('pcm-processor', PCMProcessor)

--- a/dev/public/pcm-worklet.js
+++ b/dev/public/pcm-worklet.js
@@ -5,6 +5,27 @@ class PCMProcessor extends AudioWorkletProcessor {
 		super()
 		this._chunks = []
 		this._count = 0
+		this.port.onmessage = (event) => {
+			if (event.data === 'flush') {
+				this._flush()
+				this.port.postMessage('flushed')
+			}
+		}
+	}
+
+	_flush() {
+		if (this._count === 0) return
+		const pcm = new Int16Array(this._count)
+		let offset = 0
+		for (const chunk of this._chunks) {
+			for (let i = 0; i < chunk.length; i++) {
+				const s = Math.max(-1, Math.min(1, chunk[i]))
+				pcm[offset++] = s < 0 ? s * 0x8000 : s * 0x7fff
+			}
+		}
+		this.port.postMessage(pcm.buffer, [pcm.buffer])
+		this._chunks = []
+		this._count = 0
 	}
 
 	process(inputs) {
@@ -13,19 +34,7 @@ class PCMProcessor extends AudioWorkletProcessor {
 			this._chunks.push(channel.slice(0))
 			this._count += channel.length
 
-			if (this._count >= TARGET_SAMPLES) {
-				const pcm = new Int16Array(this._count)
-				let offset = 0
-				for (const chunk of this._chunks) {
-					for (let i = 0; i < chunk.length; i++) {
-						const s = Math.max(-1, Math.min(1, chunk[i]))
-						pcm[offset++] = s < 0 ? s * 0x8000 : s * 0x7fff
-					}
-				}
-				this.port.postMessage(pcm.buffer, [pcm.buffer])
-				this._chunks = []
-				this._count = 0
-			}
+			if (this._count >= TARGET_SAMPLES) this._flush()
 		}
 		return true
 	}

--- a/dev/src/App.tsx
+++ b/dev/src/App.tsx
@@ -11,6 +11,7 @@ import { Footer } from './components/Footer'
 import { DefaultButtonCard } from './cards/DefaultButtonCard'
 import { CommandsCard } from './cards/CommandsCard'
 import { DictationCard } from './cards/DictationCard'
+import { GladiaCard } from './cards/GladiaCard'
 import { RenderPropCard } from './cards/RenderPropCard'
 import { ErrorsCard } from './cards/ErrorsCard'
 import { UseVocalCard } from './cards/UseVocalCard'
@@ -37,8 +38,8 @@ export const App = () => {
 					</h1>
 					<p>
 						react-vocal wraps the browser’s SpeechRecognition into a component and a hook — voice commands,
-						live dictation, custom buttons and typed error handling. Every card below is live; open “View
-						source” to see the exact code.
+						live dictation, custom buttons, pluggable cloud engines and typed error handling. Every card
+						below is live; open “View source” to see the exact code.
 					</p>
 					<div className="intro__meta">
 						<span>Click a mic and speak — recognition happens in your browser.</span>
@@ -56,7 +57,7 @@ export const App = () => {
 
 				<h2 className="section-title">Explore the API</h2>
 				<p className="section-lead">
-					Eight focused examples, one capability each — from the drop-in button to feature detection.
+					Nine focused examples, one capability each — from the drop-in button to a Gladia cloud engine.
 				</p>
 
 				<LanguageSelector value={lang} onChange={setLang} />
@@ -65,6 +66,7 @@ export const App = () => {
 					<DefaultButtonCard supported={supported} lang={lang} />
 					<CommandsCard supported={supported} lang={lang} />
 					<DictationCard supported={supported} lang={lang} />
+					<GladiaCard lang={lang} />
 					<RenderPropCard supported={supported} lang={lang} />
 					<UseVocalCard supported={supported} lang={lang} />
 					<UseCommandsCard />

--- a/dev/src/cards/GladiaCard.tsx
+++ b/dev/src/cards/GladiaCard.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useMemo, useState } from 'react'
+
+import { Vocal, isSupported } from '@untemps/react-vocal'
+
+import { Card } from '../components/Card'
+import { Pill, StatusPill } from '../components/Pill'
+import { createGladiaEngine } from '../lib/gladiaEngine'
+
+const CODE = `import { Vocal } from '@untemps/react-vocal'
+import { createGladiaEngine } from './gladiaEngine'
+
+const engine = useMemo(() => createGladiaEngine({ apiKey }), [apiKey])
+
+<Vocal
+  engine={engine}       // swap the Web Speech API for Gladia
+  lang="en-US"
+  continuous            // stream until the mic is clicked again
+  interimResults        // live partial transcripts while speaking
+  onResult={(text, event) => {
+    // interims stream live; the aggregated transcript arrives on stop
+    const isFinal = event.results?.[event.resultIndex]?.isFinal
+    isFinal ? commit(text) : setLiveCaption(text)
+  }}
+/>`
+
+export const GladiaCard = ({ lang }: { lang: string }) => {
+	const [apiKey, setApiKey] = useState((import.meta.env.VITE_GLADIA_API_KEY ?? '').trim())
+	const [committed, setCommitted] = useState('')
+	const [interim, setInterim] = useState('')
+	const [listening, setListening] = useState(false)
+	const [error, setError] = useState<string | null>(null)
+
+	const key = apiKey.trim()
+	const engine = useMemo(() => (key ? createGladiaEngine({ apiKey: key }) : undefined), [key])
+	const supported = useMemo(() => isSupported(createGladiaEngine({ apiKey: '' })), [])
+
+	useEffect(() => {
+		setListening(false)
+		setInterim('')
+		setError(null)
+	}, [key])
+
+	const onResult = (text: string, event: SpeechRecognitionEvent | Event) => {
+		const srEvent = event as SpeechRecognitionEvent
+		const segment = srEvent.results?.[srEvent.resultIndex ?? 0]
+		const isFinal = segment ? segment.isFinal !== false : true
+		if (isFinal) {
+			setCommitted((prev) => `${prev}${prev ? ' ' : ''}${text}`.trim())
+			setInterim('')
+		} else {
+			setInterim(text)
+		}
+	}
+
+	return (
+		<Card
+			title="Custom engine — Gladia"
+			badge="engine"
+			description="The same <Vocal> component, driven by a cloud engine instead of the browser's Web Speech API. Pass an engine factory and Vocal streams the mic to Gladia over a WebSocket — bringing recognition to browsers without SpeechRecognition (e.g. Firefox). The live caption streams while you speak; the full transcript commits when you stop."
+			code={CODE}
+		>
+			<div className="card__stage">
+				{!supported ? (
+					<p className="hint">
+						This browser can’t reach a cloud engine — WebSocket or microphone capture is unavailable.
+					</p>
+				) : (
+					<>
+						<label className="control control--inline" style={{ width: '100%' }}>
+							<span className="control__label">Gladia API key</span>
+							<input
+								className="field field--sm"
+								type="password"
+								autoComplete="off"
+								placeholder="paste your key…"
+								value={apiKey}
+								onChange={(e) => setApiKey(e.target.value)}
+								style={{ flex: 1 }}
+							/>
+						</label>
+
+						<div className="control__row" style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+							<div className="pill-row">
+								<StatusPill listening={listening} />
+								{error && <Pill tone="danger">{error}</Pill>}
+							</div>
+						</div>
+
+						<div style={{ display: 'flex', justifyContent: 'center' }}>
+							{key ? (
+								<Vocal
+									engine={engine}
+									lang={lang}
+									continuous
+									interimResults
+									style={{ width: 44, height: 44 }}
+									onStart={() => {
+										setListening(true)
+										setInterim('')
+										setError(null)
+									}}
+									onEnd={() => {
+										setListening(false)
+										setInterim('')
+									}}
+									onResult={onResult}
+									onError={(err) => {
+										setListening(false)
+										setError(err.message)
+									}}
+								/>
+							) : (
+								<p className="hint">Paste a Gladia API key above to try the cloud engine.</p>
+							)}
+						</div>
+
+						<p className="transcript" aria-live="polite">
+							{committed}
+							{interim && (
+								<span className="transcript__interim">
+									{committed ? ' ' : ''}
+									{interim}
+								</span>
+							)}
+							{!committed && !interim && (
+								<span className="transcript__placeholder">Press the mic and start dictating…</span>
+							)}
+						</p>
+
+						{committed && (
+							<button type="button" className="btn btn--ghost" onClick={() => setCommitted('')}>
+								Clear
+							</button>
+						)}
+
+						<p className="hint">
+							Get a free key at gladia.io. The key stays in your browser and is proxied through Vite in
+							this demo — never ship a raw key to production; mint short-lived credentials server-side.
+						</p>
+					</>
+				)}
+			</div>
+		</Card>
+	)
+}

--- a/dev/src/lib/gladiaEngine.ts
+++ b/dev/src/lib/gladiaEngine.ts
@@ -1,0 +1,173 @@
+import {
+	createEngine,
+	type EngineConnectContext,
+	type EngineSession,
+	type SpeechEngineFactory,
+} from '@untemps/react-vocal'
+
+const GLADIA_INIT_URL = '/gladia-api/v2/live'
+const SAMPLE_RATE = 16000
+const STOP_GRACE_MS = 2000
+
+interface GladiaConfig {
+	apiKey: string
+}
+
+interface GladiaMessage {
+	type?: string
+	data?: { is_final?: boolean; utterance?: { text?: string } }
+}
+
+export const createGladiaEngine = ({ apiKey }: GladiaConfig): SpeechEngineFactory =>
+	createEngine({
+		isSupported: () => typeof WebSocket !== 'undefined',
+		connect: async ({
+			stream,
+			signal,
+			language,
+			options,
+			emitTranscript,
+			emitError,
+			end,
+		}: EngineConnectContext): Promise<EngineSession> => {
+			let audioContext: AudioContext | null = null
+			let workletNode: AudioWorkletNode | null = null
+			let source: MediaStreamAudioSourceNode | null = null
+			let closed = false
+			let closeTimer: ReturnType<typeof setTimeout> | null = null
+
+			const clearCloseTimer = (): void => {
+				if (closeTimer !== null) {
+					clearTimeout(closeTimer)
+					closeTimer = null
+				}
+			}
+
+			const releaseAudio = (): void => {
+				workletNode?.disconnect()
+				source?.disconnect()
+				stream.getTracks().forEach((track) => track.stop())
+				audioContext?.close()
+				workletNode = source = audioContext = null
+			}
+
+			const initSession = async (sampleRate: number): Promise<string> => {
+				const response = await fetch(GLADIA_INIT_URL, {
+					method: 'POST',
+					signal,
+					headers: { 'x-gladia-key': apiKey, 'content-type': 'application/json' },
+					body: JSON.stringify({
+						encoding: 'wav/pcm',
+						sample_rate: sampleRate,
+						bit_depth: 16,
+						channels: 1,
+						language_config: { languages: [language] },
+						messages_config: { receive_partial_transcripts: options.interimResults },
+					}),
+				})
+				if (!response.ok) {
+					throw new Error(`Gladia init failed (${response.status} ${response.statusText})`)
+				}
+				const { url } = (await response.json()) as { url: string }
+				return url
+			}
+
+			const startAudio = async (socket: WebSocket): Promise<void> => {
+				await audioContext!.resume()
+				await audioContext!.audioWorklet.addModule('/pcm-worklet.js')
+				source = audioContext!.createMediaStreamSource(stream)
+				workletNode = new AudioWorkletNode(audioContext!, 'pcm-processor')
+				workletNode.port.onmessage = (event: MessageEvent<ArrayBuffer>) => {
+					if (socket.readyState === WebSocket.OPEN) socket.send(event.data)
+				}
+				source.connect(workletNode)
+				workletNode.connect(audioContext!.destination)
+			}
+
+			const handleMessage = (event: MessageEvent): void => {
+				if (closed) return
+				let message: GladiaMessage
+				try {
+					message = JSON.parse(event.data as string)
+				} catch {
+					return
+				}
+				if (message.type !== 'transcript') return
+				emitTranscript(message.data?.utterance?.text ?? '', { isFinal: message.data?.is_final ?? false })
+			}
+
+			try {
+				audioContext = new AudioContext({ sampleRate: SAMPLE_RATE })
+				const url = await initSession(audioContext.sampleRate)
+				const socket = await new Promise<WebSocket>((resolve, reject) => {
+					let opened = false
+					const ws = new WebSocket(url)
+					const onAbort = () => {
+						ws.onclose = null
+						ws.close()
+						const error = new Error('Aborted')
+						error.name = 'AbortError'
+						reject(error)
+					}
+					if (signal?.aborted) return onAbort()
+					signal?.addEventListener('abort', onAbort, { once: true })
+					const clearAbort = () => signal?.removeEventListener('abort', onAbort)
+					ws.onopen = () => {
+						startAudio(ws).then(
+							() => {
+								clearAbort()
+								opened = true
+								resolve(ws)
+							},
+							(error) => {
+								clearAbort()
+								ws.onclose = null
+								ws.close()
+								reject(error)
+							}
+						)
+					}
+					ws.onmessage = handleMessage
+					ws.onerror = () => {
+						clearAbort()
+						if (opened && !closed) emitError('Gladia WebSocket error')
+						reject(new Error('Gladia WebSocket error'))
+					}
+					ws.onclose = () => {
+						if (!opened) {
+							clearAbort()
+							reject(new Error('Gladia WebSocket closed before opening'))
+							return
+						}
+						if (closed) return
+						closed = true
+						clearCloseTimer()
+						releaseAudio()
+						end({ flush: true })
+					}
+				})
+
+				return {
+					stop() {
+						if (closed) return
+						if (socket.readyState === WebSocket.OPEN) {
+							socket.send(JSON.stringify({ type: 'stop_recording' }))
+						}
+						releaseAudio()
+						closeTimer = setTimeout(() => socket.close(), STOP_GRACE_MS)
+					},
+					abort() {
+						if (closed) return
+						closed = true
+						clearCloseTimer()
+						socket.onclose = null
+						socket.close()
+						releaseAudio()
+					},
+				}
+			} catch (error) {
+				releaseAudio()
+				throw error
+			}
+		},
+	})

--- a/dev/src/lib/gladiaEngine.ts
+++ b/dev/src/lib/gladiaEngine.ts
@@ -8,6 +8,7 @@ import {
 const GLADIA_INIT_URL = '/gladia-api/v2/live'
 const SAMPLE_RATE = 16000
 const STOP_GRACE_MS = 2000
+const FLUSH_TIMEOUT_MS = 200
 
 interface GladiaConfig {
 	apiKey: string
@@ -34,7 +35,10 @@ export const createGladiaEngine = ({ apiKey }: GladiaConfig): SpeechEngineFactor
 			let workletNode: AudioWorkletNode | null = null
 			let source: MediaStreamAudioSourceNode | null = null
 			let closed = false
+			let stopping = false
+			let errored = false
 			let closeTimer: ReturnType<typeof setTimeout> | null = null
+			let onFlushed: (() => void) | null = null
 
 			const clearCloseTimer = (): void => {
 				if (closeTimer !== null) {
@@ -43,12 +47,17 @@ export const createGladiaEngine = ({ apiKey }: GladiaConfig): SpeechEngineFactor
 				}
 			}
 
-			const releaseAudio = (): void => {
-				workletNode?.disconnect()
+			const stopMic = (): void => {
 				source?.disconnect()
 				stream.getTracks().forEach((track) => track.stop())
+				source = null
+			}
+
+			const releaseAudio = (): void => {
+				stopMic()
+				workletNode?.disconnect()
 				audioContext?.close()
-				workletNode = source = audioContext = null
+				workletNode = audioContext = null
 			}
 
 			const initSession = async (sampleRate: number): Promise<string> => {
@@ -77,7 +86,11 @@ export const createGladiaEngine = ({ apiKey }: GladiaConfig): SpeechEngineFactor
 				await audioContext!.audioWorklet.addModule('/pcm-worklet.js')
 				source = audioContext!.createMediaStreamSource(stream)
 				workletNode = new AudioWorkletNode(audioContext!, 'pcm-processor')
-				workletNode.port.onmessage = (event: MessageEvent<ArrayBuffer>) => {
+				workletNode.port.onmessage = (event: MessageEvent<ArrayBuffer | string>) => {
+					if (event.data === 'flushed') {
+						onFlushed?.()
+						return
+					}
 					if (socket.readyState === WebSocket.OPEN) socket.send(event.data)
 				}
 				source.connect(workletNode)
@@ -130,10 +143,13 @@ export const createGladiaEngine = ({ apiKey }: GladiaConfig): SpeechEngineFactor
 					ws.onmessage = handleMessage
 					ws.onerror = () => {
 						clearAbort()
-						if (opened && !closed) emitError('Gladia WebSocket error')
+						if (opened && !closed) {
+							errored = true
+							emitError('Gladia WebSocket error')
+						}
 						reject(new Error('Gladia WebSocket error'))
 					}
-					ws.onclose = () => {
+					ws.onclose = (event) => {
 						if (!opened) {
 							clearAbort()
 							reject(new Error('Gladia WebSocket closed before opening'))
@@ -143,18 +159,47 @@ export const createGladiaEngine = ({ apiKey }: GladiaConfig): SpeechEngineFactor
 						closed = true
 						clearCloseTimer()
 						releaseAudio()
-						end({ flush: true })
+						// Only a user-initiated stop flushes the aggregated transcript as a final
+						// result; a server/network close is surfaced as an error, not a success.
+						if (stopping) {
+							end({ flush: true })
+						} else {
+							if (!errored) emitError(`Gladia WebSocket closed unexpectedly (${event.code})`)
+							end()
+						}
 					}
 				})
 
 				return {
 					stop() {
-						if (closed) return
-						if (socket.readyState === WebSocket.OPEN) {
-							socket.send(JSON.stringify({ type: 'stop_recording' }))
+						if (closed || stopping) return
+						stopping = true
+						stopMic()
+						const finalize = (): void => {
+							// Signal end-of-audio only after the tail has been drained to the socket.
+							if (socket.readyState === WebSocket.OPEN) {
+								socket.send(JSON.stringify({ type: 'stop_recording' }))
+							}
+							onFlushed = null
+							closeTimer = setTimeout(() => socket.close(), STOP_GRACE_MS)
 						}
-						releaseAudio()
-						closeTimer = setTimeout(() => socket.close(), STOP_GRACE_MS)
+						if (!workletNode) {
+							releaseAudio()
+							finalize()
+							return
+						}
+						// Drain the worklet's sub-threshold tail (<100ms) to the socket before
+						// signalling end-of-audio, else Gladia finalizes without the last word.
+						let drained = false
+						const finish = (): void => {
+							if (drained || closed) return
+							drained = true
+							releaseAudio()
+							finalize()
+						}
+						onFlushed = finish
+						setTimeout(finish, FLUSH_TIMEOUT_MS)
+						workletNode.port.postMessage('flush')
 					},
 					abort() {
 						if (closed) return

--- a/dev/src/vite-env.d.ts
+++ b/dev/src/vite-env.d.ts
@@ -1,5 +1,13 @@
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+	readonly VITE_GLADIA_API_KEY?: string
+}
+
+interface ImportMeta {
+	readonly env: ImportMetaEnv
+}
+
 declare const process: {
 	env: {
 		NODE_ENV?: string

--- a/dev/vite.config.ts
+++ b/dev/vite.config.ts
@@ -12,5 +12,12 @@ export default defineConfig({
 	server: {
 		port: 10001,
 		open: true,
+		proxy: {
+			'/gladia-api': {
+				target: 'https://api.gladia.io',
+				changeOrigin: true,
+				rewrite: (path) => path.replace(/^\/gladia-api/, ''),
+			},
+		},
 	},
 })

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
 		}
 	},
 	"dependencies": {
-		"@untemps/vocal": "^2.2.0"
+		"@untemps/vocal": "^2.3.5"
 	},
 	"release": {
 		"branches": [

--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -11,7 +11,7 @@ import {
 	type ReactElement,
 	type ReactNode,
 } from 'react'
-import { isSupported as isSupportedFn } from '@untemps/vocal'
+import { isSupported as isSupportedFn, type SpeechEngineFactory } from '@untemps/vocal'
 import { isFunction } from '@untemps/utils/function/isFunction'
 
 import { useVocal } from '../hooks/useVocal'
@@ -94,6 +94,7 @@ export interface VocalProps {
 	maxAlternatives?: number
 	continuous?: boolean
 	interimResults?: boolean
+	engine?: SpeechEngineFactory
 	ariaLabel?: string
 	style?: CSSProperties | null
 	className?: string | null
@@ -134,6 +135,7 @@ export const Vocal = ({
 	maxAlternatives = 1,
 	continuous = false,
 	interimResults = false,
+	engine,
 	ariaLabel = 'start recognition',
 	style = null,
 	className = null,
@@ -149,14 +151,15 @@ export const Vocal = ({
 	signal = null,
 }: VocalProps) => {
 	const [isFocused, setIsFocused] = useState(false)
-	const isSupported = useMemo(() => isSupportedFn(), [])
+	const isSupported = useMemo(() => isSupportedFn(engine), [engine])
 
 	const [, { start, stop, subscribe, unsubscribe, isRecording: isListening, permissionState }] = useVocal(
 		lang,
 		grammars,
 		maxAlternatives,
 		continuous,
-		interimResults
+		interimResults,
+		engine
 	)
 	const triggerCommand = useCommands(commands, precision)
 

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -1,7 +1,7 @@
 import { type FormEvent as ReactFormEvent, type MouseEvent as ReactMouseEvent } from 'react'
 import { waitFor } from '@testing-library/dom'
 import { act, fireEvent, render } from '@testing-library/react'
-import { createVocal, isSupported, type VocalInstance } from '@untemps/vocal'
+import { createVocal, isSupported, type SpeechEngineFactory, type VocalInstance } from '@untemps/vocal'
 
 import { DEFAULT_OUTLINE_STYLE, Vocal, type VocalProps } from '../Vocal'
 import { createMockVocal } from './createMockVocal'
@@ -55,6 +55,24 @@ describe('Vocal', () => {
 		const { queryByTestId } = render(getInstance(null, <div data-testid="__vocal-custom-root__" />))
 		expect(queryByTestId('__vocal-root__')).not.toBeInTheDocument()
 		expect(queryByTestId('__vocal-custom-root__')).toBeInTheDocument()
+	})
+
+	it('forwards a custom engine to createVocal', () => {
+		const engine = Object.assign(() => {}, { isSupported: () => true }) as unknown as SpeechEngineFactory
+		render(getInstance({ __rsInstance: createMockVocal(), engine }))
+		expect(createVocal).toHaveBeenCalledWith(expect.objectContaining({ engine }))
+	})
+
+	it('probes support with the custom engine', () => {
+		const engine = Object.assign(() => {}, { isSupported: () => true }) as unknown as SpeechEngineFactory
+		render(getInstance({ __rsInstance: createMockVocal(), engine }))
+		expect(isSupported).toHaveBeenCalledWith(engine)
+	})
+
+	it('renders nothing when the custom engine reports unsupported', () => {
+		const engine = Object.assign(() => {}, { isSupported: () => false }) as unknown as SpeechEngineFactory
+		const { queryByTestId } = render(getInstance({ engine }))
+		expect(queryByTestId('__vocal-root__')).not.toBeInTheDocument()
 	})
 
 	it('toggles recognition with custom children element (start then stop)', async () => {

--- a/src/hooks/__tests__/useVocal.test.ts
+++ b/src/hooks/__tests__/useVocal.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react'
-import { createVocal, isSupported } from '@untemps/vocal'
+import { createVocal, isSupported, type SpeechEngineFactory } from '@untemps/vocal'
 
 import { useVocal } from '../useVocal'
 
@@ -167,6 +167,35 @@ describe('useVocal', () => {
 
 			expect(createVocal).toHaveBeenCalledTimes(2)
 			expect(createVocal).toHaveBeenLastCalledWith(expect.objectContaining({ interimResults: true }))
+			expect(mockAbort).toHaveBeenCalledTimes(1)
+			expect(mockCleanup).toHaveBeenCalledTimes(1)
+		})
+
+		it('passes a custom engine to createVocal factory', () => {
+			const engine = (() => {}) as unknown as SpeechEngineFactory
+			renderHook(() => useVocal('en-US', null, 1, false, false, engine))
+			expect(createVocal).toHaveBeenCalledWith(expect.objectContaining({ engine }))
+		})
+
+		it('probes support with the provided engine', () => {
+			const engine = (() => {}) as unknown as SpeechEngineFactory
+			renderHook(() => useVocal('en-US', null, 1, false, false, engine))
+			expect(isSupported).toHaveBeenCalledWith(engine)
+		})
+
+		it('tears down and recreates the instance when engine identity changes', () => {
+			const engine1 = (() => {}) as unknown as SpeechEngineFactory
+			const engine2 = (() => {}) as unknown as SpeechEngineFactory
+			const { rerender } = renderHook(({ engine }) => useVocal('en-US', null, 1, false, false, engine), {
+				initialProps: { engine: engine1 },
+			})
+			expect(createVocal).toHaveBeenCalledTimes(1)
+			expect(createVocal).toHaveBeenLastCalledWith(expect.objectContaining({ engine: engine1 }))
+
+			rerender({ engine: engine2 })
+
+			expect(createVocal).toHaveBeenCalledTimes(2)
+			expect(createVocal).toHaveBeenLastCalledWith(expect.objectContaining({ engine: engine2 }))
 			expect(mockAbort).toHaveBeenCalledTimes(1)
 			expect(mockCleanup).toHaveBeenCalledTimes(1)
 		})

--- a/src/hooks/useVocal.ts
+++ b/src/hooks/useVocal.ts
@@ -5,6 +5,7 @@ import {
 	type EventHandlerFor,
 	type EventType,
 	type GenericEventHandler,
+	type SpeechEngineFactory,
 	type VocalInstance,
 } from '@untemps/vocal'
 
@@ -32,17 +33,18 @@ export const useVocal = (
 	grammars: SpeechGrammarList | null = null,
 	maxAlternatives: number = 1,
 	continuous: boolean = false,
-	interimResults: boolean = false
+	interimResults: boolean = false,
+	engine?: SpeechEngineFactory
 ): UseVocalReturn => {
 	const ref = useRef<VocalInstance | null>(null)
 	const subscriptionsRef = useRef<Array<[EventType | string, EventHandlerFor<EventType> | GenericEventHandler]>>([])
 	const [isRecording, setIsRecording] = useState(false)
 	const [permissionState, setPermissionState] = useState<PermissionState | null>(null)
-	const supported = useMemo(() => isSupported(), [])
+	const supported = useMemo(() => isSupported(engine), [engine])
 
 	useEffect(() => {
 		if (supported) {
-			const instance = createVocal({ lang, grammars, maxAlternatives, continuous, interimResults })
+			const instance = createVocal({ lang, grammars, maxAlternatives, continuous, interimResults, engine })
 			ref.current = instance
 
 			const handleStart = () => setIsRecording(true)
@@ -72,7 +74,7 @@ export const useVocal = (
 				setPermissionState(null)
 			}
 		}
-	}, [lang, grammars, maxAlternatives, continuous, interimResults, supported])
+	}, [lang, grammars, maxAlternatives, continuous, interimResults, engine, supported])
 
 	const start = useCallback(async (options?: { signal?: AbortSignal }): Promise<void> => {
 		const instance = ref.current

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,13 @@ export {
 } from './components/Vocal'
 export { useVocal, type UseVocalActions, type UseVocalReturn } from './hooks/useVocal'
 export { useCommands, type CommandCallback, type CommandsMap, type TriggerCommand } from './hooks/useCommands'
-export { isSupported } from '@untemps/vocal'
+export { isSupported, createEngine, WebSpeechEngine } from '@untemps/vocal'
+export type {
+	SpeechEngineFactory,
+	SpeechEngineInstance,
+	SpeechEngineContext,
+	CreateVocalOptions,
+	EngineBackend,
+	EngineSession,
+	EngineConnectContext,
+} from '@untemps/vocal'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1393,10 +1393,10 @@
   resolved "https://registry.yarnpkg.com/@untemps/utils/-/utils-3.2.0.tgz#dc26d65d54e4a5e9b940b5c7f65832f60ff283dd"
   integrity sha512-P48fcASTI8LSngn8cYjDq8KkasjDLghOnDmMatjwTLp0/qwp8/sifYuAJDODCqXXr7xATxcTnkULzNdZqavuNA==
 
-"@untemps/vocal@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@untemps/vocal/-/vocal-2.2.0.tgz#bccc70ce4e813ff6544afccdf0e61963b4bf147f"
-  integrity sha512-pZrrUjCmUX9mVKeRjAHRhK0n6vKA+3BrimuXmPQgT4jkZxatKAcc53/z0Now3J2c2WKiWBd3n96VVUfCxD2UBQ==
+"@untemps/vocal@^2.3.5":
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/@untemps/vocal/-/vocal-2.3.5.tgz#ae5aa4b7e0c2f6532abdeb1d28d8d39e9a9de698"
+  integrity sha512-MR59cgFRhyIxpKxh/fKgsnAZx3WBKcDvFVMWJJdoiQJevUrAOGQX6JpK7hSX9CJOA8bIAZptBOuFa7NmhCjFog==
   dependencies:
     "@untemps/user-permissions-utils" "^2.2.3"
 


### PR DESCRIPTION
## Summary

Adds support for `@untemps/vocal` 2.3.x **custom speech engines** to `react-vocal`, and a Gladia demo card mirroring vocal's own demo.

- Bumps `@untemps/vocal` `^2.2.0` → `^2.3.5`.
- Threads a custom `engine` (`SpeechEngineFactory`) through the library:
  - `useVocal(lang, grammars, maxAlternatives, continuous, interimResults, engine)` — new 6th argument.
  - `<Vocal engine={…}>` — new prop.
  - Both forward to `createVocal`; support is probed via `isSupported(engine)`; the instance is rebuilt when the engine identity changes.
- Re-exports the engine authoring surface from `src/index.ts`: `createEngine`, `WebSpeechEngine`, and the engine types (`SpeechEngineFactory`, `SpeechEngineInstance`, `SpeechEngineContext`, `CreateVocalOptions`, `EngineBackend`, `EngineConnectContext`, `EngineSession`).
- Omitting `engine` keeps the built-in Web Speech engine — **fully backward compatible**.

## Demo

- New **"Custom engine — Gladia"** card (`dev/src/cards/GladiaCard.tsx`) driving the same `<Vocal>` component with a Gladia cloud engine.
- Gladia engine ported from vocal's demo (`dev/src/lib/gladiaEngine.ts` + `dev/public/pcm-worklet.js`): streams PCM16 over a WebSocket, converting Float32 → PCM16 in an `AudioWorklet`.
- `/gladia-api` proxied to `api.gladia.io` in the Vite dev server; API key entered at runtime (or from `VITE_GLADIA_API_KEY`).

## Docs

README: the `engine` prop/argument, a **Custom speech engines** section, `isSupported(engine)`, the re-exported authoring surface, and a Gladia example.

## Verification

- ✅ `yarn typecheck` (lib + demo), `yarn lint`
- ✅ 219 tests (6 new: engine forwarding, support probing, instance recreation on engine change), coverage above thresholds
- ✅ `yarn build` + `verify-bundle`, demo build, dev-server smoke test
- ✅ Adversarial multi-agent review — 5 low-severity findings, all fixed

> Note: the live Gladia transcription path (real key + mic + browser) was not exercised end-to-end; the engine is a faithful port of vocal's reference and the whole chain (types, alias, worklet serving, proxy) is validated at build/runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
