### PR TITLE
fix: Keep optional fuse.js import consumer-ignorable so webpack builds don't break when absent

### DIFF
--- a/scripts/verify-bundle.mjs
+++ b/scripts/verify-bundle.mjs
@@ -56,11 +56,6 @@ for (const bundle of bundles) {
 		)
 	}
 
-	// fuse.js is an optional peer. Its lazy import() must carry a `webpackIgnore`
-	// marker so consumer bundlers (webpack/CRA/Next) leave it to runtime resolution
-	// instead of statically resolving it and failing the build when it is absent.
-	// The library minifier strips the comment, so the build ships unminified — this
-	// guard fails if the marker ever disappears (e.g. minify gets re-enabled).
 	const fuseImport = source.match(/import\(([^)]*fuse\.js[^)]*)\)/)
 	if (fuseImport && !fuseImport[1].includes('webpackIgnore')) {
 		errors.push(

--- a/scripts/verify-bundle.mjs
+++ b/scripts/verify-bundle.mjs
@@ -55,6 +55,19 @@ for (const bundle of bundles) {
 				`externalized as expected (see issue #267).`,
 		)
 	}
+
+	// fuse.js is an optional peer. Its lazy import() must carry a `webpackIgnore`
+	// marker so consumer bundlers (webpack/CRA/Next) leave it to runtime resolution
+	// instead of statically resolving it and failing the build when it is absent.
+	// The library minifier strips the comment, so the build ships unminified — this
+	// guard fails if the marker ever disappears (e.g. minify gets re-enabled).
+	const fuseImport = source.match(/import\(([^)]*fuse\.js[^)]*)\)/)
+	if (fuseImport && !fuseImport[1].includes('webpackIgnore')) {
+		errors.push(
+			`${bundle}: the import('fuse.js') lost its "webpackIgnore" marker — ` +
+				`consumer bundlers will hard-resolve the optional fuse.js peer and break builds when it is absent.`,
+		)
+	}
 }
 
 if (errors.length > 0) {
@@ -63,4 +76,6 @@ if (errors.length > 0) {
 	process.exit(1)
 }
 
-console.log(`✔ Bundle verification passed: ${bundles.join(', ')} keep react/jsx-runtime external.`)
+console.log(
+	`✔ Bundle verification passed: ${bundles.join(', ')} keep react/jsx-runtime external and fuse.js consumer-ignorable.`,
+)

--- a/src/hooks/useCommands.ts
+++ b/src/hooks/useCommands.ts
@@ -32,10 +32,6 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 		// Race guard: discard the result if the effect re-runs or unmounts before the
 		// dynamic import resolves, so a stale Fuse instance can't overwrite fuseRef.current.
 		let cancelled = false
-		// webpackIgnore/@vite-ignore keep consumer bundlers from statically resolving fuse.js:
-		// it is an optional peer, so a bare import('fuse.js') fails webpack/CRA/Next builds when
-		// absent instead of falling back at runtime. The comment must survive into dist (guarded
-		// by scripts/verify-bundle.mjs).
 		import(/* webpackIgnore: true */ /* @vite-ignore */ 'fuse.js')
 			.then((module) => {
 				if (cancelled) return

--- a/src/hooks/useCommands.ts
+++ b/src/hooks/useCommands.ts
@@ -32,7 +32,11 @@ export const useCommands = (commands?: CommandsMap | null, precision: number = 0
 		// Race guard: discard the result if the effect re-runs or unmounts before the
 		// dynamic import resolves, so a stale Fuse instance can't overwrite fuseRef.current.
 		let cancelled = false
-		import('fuse.js')
+		// webpackIgnore/@vite-ignore keep consumer bundlers from statically resolving fuse.js:
+		// it is an optional peer, so a bare import('fuse.js') fails webpack/CRA/Next builds when
+		// absent instead of falling back at runtime. The comment must survive into dist (guarded
+		// by scripts/verify-bundle.mjs).
+		import(/* webpackIgnore: true */ /* @vite-ignore */ 'fuse.js')
 			.then((module) => {
 				if (cancelled) return
 				const FuseCtor = (module.default ?? module) as unknown as typeof Fuse

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,9 +29,6 @@ export default defineConfig({
 		rollupOptions: {
 			external: [/^react($|\/)/, /^react-dom($|\/)/, 'fuse.js', '@untemps/vocal'],
 		},
-		// Ship unminified so the `webpackIgnore`/`@vite-ignore` magic comment on the optional
-		// import('fuse.js') survives into both bundles; the minifier strips it (see verify-bundle.mjs).
-		// Consumers minify downstream, and the bundle stays tiny.
 		minify: false,
 		sourcemap: true,
 	},

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,6 +29,10 @@ export default defineConfig({
 		rollupOptions: {
 			external: [/^react($|\/)/, /^react-dom($|\/)/, 'fuse.js', '@untemps/vocal'],
 		},
+		// Ship unminified so the `webpackIgnore`/`@vite-ignore` magic comment on the optional
+		// import('fuse.js') survives into both bundles; the minifier strips it (see verify-bundle.mjs).
+		// Consumers minify downstream, and the bundle stays tiny.
+		minify: false,
 		sourcemap: true,
 	},
 	test: {


### PR DESCRIPTION
## Problem

`fuse.js` is documented as an **optional** peer dependency with an exact-matching fallback (README §Commands / §useCommands / installation notes), so consumers who only use single-word commands are told they can skip installing it.

But `useCommands` used a bare `import('fuse.js')`, which is emitted **verbatim** into both published bundles. Consumer bundlers that statically analyze dynamic imports — **webpack, Create React App, Next.js in webpack mode** — try to resolve `fuse.js` at *build time* and fail hard:

```
Module not found: Error: Can't resolve 'fuse.js'
```

The runtime `.catch(...)` fallback never runs, because the failure is at the consumer's compile step. `useCommands` is mounted by every `<Vocal>`, so even consumers who never pass phrase commands hit it. Net effect: the advertised "optional" dependency is effectively **mandatory** for the entire webpack ecosystem — a merge-blocker for the 2.0 major.

Vite / Rollup / esbuild consumers were unaffected (they tolerate the unresolved external), which is why it slipped through.

## Fix

- Annotate the lazy import with `/* webpackIgnore: true */ /* @vite-ignore */` so consumer bundlers leave `fuse.js` to **runtime** resolution and the documented fallback path works as advertised.
- The library minifier strips the magic comment, so the lib now **ships unminified** (`build.minify: false`). Both bundles stay tiny (~15 kB, ~4.4 kB gzip) and consumers minify downstream anyway.
- Extend `scripts/verify-bundle.mjs` (the existing `postbuild` guard, same pattern as the jsx-runtime guard from #267) to **fail the build** if the `webpackIgnore` marker ever disappears from either bundle — e.g. if minification gets re-enabled.

## Verification

- ✅ `yarn build` + `verify-bundle.mjs`: `webpackIgnore` confirmed present inside `import(...)` in **both** `dist/index.es.js` and `dist/index.cjs`.
- ✅ Negative test: manually stripping the marker makes the guard fail with a clear message (exit 1).
- ✅ `yarn lint`, `yarn typecheck`, `yarn test:ci` (219 tests, coverage green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)