### PR TITLE
fix: Restore native focus ring when outlineStyle is falsy on the default button

### DIFF
--- a/src/components/Vocal.tsx
+++ b/src/components/Vocal.tsx
@@ -354,7 +354,7 @@ export const Vocal = ({
 							padding: 0,
 							cursor: 'pointer',
 							...(style ?? {}),
-							outline: isFocused && outlineStyle ? outlineStyle : 'none',
+							...(outlineStyle ? { outline: isFocused ? outlineStyle : 'none' } : {}),
 						}
 			}
 			className={className ?? undefined}

--- a/src/components/__tests__/Vocal.test.tsx
+++ b/src/components/__tests__/Vocal.test.tsx
@@ -332,6 +332,18 @@ describe('Vocal', () => {
 		expect(getByTestId('__vocal-root__')).toHaveStyle({ outline: outlineStyle })
 	})
 
+	it('keeps the native focus ring when outlineStyle is null', () => {
+		const { getByTestId } = render(getInstance({ outlineStyle: null }))
+		fireEvent.focus(getByTestId('__vocal-root__'))
+		expect(getByTestId('__vocal-root__')).not.toHaveStyle({ outline: 'none' })
+	})
+
+	it('preserves a consumer style.outline when outlineStyle is null', () => {
+		const outline = '2px dotted green'
+		const { getByTestId } = render(getInstance({ outlineStyle: null, style: { outline } }))
+		expect(getByTestId('__vocal-root__')).toHaveStyle({ outline })
+	})
+
 	it('not uses style when className is set', () => {
 		const { getByTestId } = render(getInstance({ className: 'foo' }))
 		expect(getByTestId('__vocal-root__')).not.toHaveStyle({ cursor: 'pointer' })


### PR DESCRIPTION
## Problem

The default button hardcoded the focus outline as:

```ts
outline: isFocused && outlineStyle ? outlineStyle : 'none'
```

With a **falsy `outlineStyle`** (e.g. `outlineStyle={null}` or `''`) this resolves to `outline: 'none'` **even while focused**, so:

- **Keyboard users lose the focus ring** — an accessibility regression versus 1.x, where a falsy `outlineStyle` left the browser's native focus ring untouched.
- Any consumer-supplied `style={{ outline: … }}` is silently **clobbered**.

This is a silent behavior break for a supported prop value (`outlineStyle={null}` was the 1.x way to opt into the native ring), so it's worth fixing before `2.0.0` is frozen.

## Fix

Only manage `outline` when an `outlineStyle` is actually set; otherwise omit the key entirely so the consumer's `style.outline` and the browser's native focus ring are preserved:

```diff
-  outline: isFocused && outlineStyle ? outlineStyle : 'none',
+  ...(outlineStyle ? { outline: isFocused ? outlineStyle : 'none' } : {}),
```

Default (`'2px solid'`) and custom `outlineStyle` behavior are unchanged.

## Tests

Two regression tests added, both verified **red on the previous code, green on the fix**:

- `keeps the native focus ring when outlineStyle is null`
- `preserves a consumer style.outline when outlineStyle is null`

## Validation

- ✅ Test suite: 221 passing (219 + 2)
- ✅ Coverage: `Vocal.tsx` 100% lines
- ✅ `yarn typecheck` clean (lib + dev)
- ✅ `yarn lint` / Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)