### PR TITLE
chore: Switch demo hosting to Vercel, refresh description, fix README demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@
 
 ## Links
 
-:red_circle:&nbsp;<big><a href="https://untemps.github.io/react-vocal" target="_blank" rel="noopener">LIVE
-DEMO</a></big>&nbsp;:red_circle:
+🔴&nbsp;**[LIVE DEMO](https://react-vocal.vercel.app)**&nbsp;🔴
 
 ## Disclaimer
 

--- a/package.json
+++ b/package.json
@@ -6,15 +6,21 @@
 	"license": "MIT",
 	"description": "React component and hook for speech recognition, with voice commands and pluggable STT engines",
 	"keywords": [
-		"Web Speech API",
-		"SpeechRecognition",
-		"speech",
+		"react",
+		"react-component",
+		"react-hook",
+		"speech-recognition",
 		"speech-to-text",
-		"React",
-		"ReactJS",
-		"component",
+		"voice-commands",
+		"voice-recognition",
+		"web-speech-api",
+		"stt",
+		"dictation",
+		"microphone",
+		"typescript",
+		"speech",
 		"hook",
-		"javascript"
+		"component"
 	],
 	"private": false,
 	"publishConfig": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"author": "Vincent Le Badezet <v.lebadezet@untemps.net>",
 	"repository": "git@github.com:untemps/react-vocal.git",
 	"license": "MIT",
-	"description": "React component and hook to initiate a SpeechRecognition session",
+	"description": "React component and hook for speech recognition, with voice commands and pluggable STT engines",
 	"keywords": [
 		"Web Speech API",
 		"SpeechRecognition",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"installCommand": "yarn install --frozen-lockfile",
+	"buildCommand": "cd dev && yarn install --frozen-lockfile && yarn build",
+	"outputDirectory": "dev/dist",
+	"rewrites": [{ "source": "/gladia-api/:path*", "destination": "https://api.gladia.io/:path*" }]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://openapi.vercel.sh/vercel.json",
-	"installCommand": "yarn install --frozen-lockfile",
+	"installCommand": "yarn install --frozen-lockfile --ignore-scripts",
 	"buildCommand": "cd dev && yarn install --frozen-lockfile && yarn build",
 	"outputDirectory": "dev/dist",
 	"rewrites": [{ "source": "/gladia-api/:path*", "destination": "https://api.gladia.io/:path*" }]


### PR DESCRIPTION
## Contexte

Ajustements de métadonnées et de déploiement de la démo sur `main`.

## Changements

- **Description projet** — `package.json` mis à jour : _React component and hook for speech recognition, with voice commands and pluggable STT engines_ (la description GitHub a déjà été alignée de mon côté).
- **Déploiement démo → Vercel** — ajout de `vercel.json` (build depuis `dev/`, sortie `dev/dist`) avec un rewrite `/gladia-api/*` → `api.gladia.io` pour que la carte Gladia continue de fonctionner hors du proxy Vite. Build de la démo vérifié localement.
- **Lien démo README** — remplacement des shortcodes `:red_circle:` et de la balise obsolète `<big>` par l'emoji Unicode 🔴 + du markdown standard, afin que le lien _LIVE DEMO_ s'affiche correctement **sur npm comme sur GitHub**, et pointage vers l'URL Vercel.

> Le lien démo utilise le placeholder `https://react-vocal.vercel.app` — à ajuster si l'URL finale du projet Vercel diffère.

## À faire après la mise en ligne de Vercel

Séquencé volontairement pour éviter un lien mort pendant la transition :

```bash
gh repo edit untemps/react-vocal --homepage https://react-vocal.vercel.app  # ajuster si besoin
gh api -X DELETE repos/untemps/react-vocal/pages   # désactive GitHub Pages
git push origin --delete gh-pages                   # supprime la branche de déploiement
```

## Note

Le commit est typé `chore:` volontairement : au merge, il déclenche une release patch qui rafraîchit la description et le README affichés sur npm (sinon la page npm garderait l'ancien texte et le rond rouge cassé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
