### PR TITLE
docs: Surface the pluggable-engine capability in the demo editorial copy

### DIFF
--- a/dev/src/App.tsx
+++ b/dev/src/App.tsx
@@ -34,12 +34,11 @@ export const App = () => {
 						Web Speech API + custom engines · React
 					</span>
 					<h1>
-						Speech recognition for React, in <span className="accent">one component</span>.
+						Speech recognition for React, in <span className="accent">one&nbsp;component</span>.
 					</h1>
 					<p>
 						Voice commands, live dictation, custom buttons and typed errors — plus a pluggable engine seam
-						that swaps the browser’s Web Speech API for a cloud or on-device backend. Every card is live;
-						open “View source” for the code.
+						that swaps the browser’s Web Speech API for a cloud or on-device backend.
 					</p>
 					<div className="intro__meta">
 						<span>

--- a/dev/src/App.tsx
+++ b/dev/src/App.tsx
@@ -31,18 +31,22 @@ export const App = () => {
 				<section className="intro">
 					<span className="intro__eyebrow">
 						<span className="brand__dot" />
-						Web Speech API · React
+						Web Speech API + custom engines · React
 					</span>
 					<h1>
 						Add voice to any React UI, in <span className="accent">one component</span>.
 					</h1>
 					<p>
-						react-vocal wraps the browser’s SpeechRecognition into a component and a hook — voice commands,
-						live dictation, custom buttons, pluggable cloud engines and typed error handling. Every card
-						below is live; open “View source” to see the exact code.
+						react-vocal turns speech recognition into a component and a hook — voice commands, live
+						dictation, custom buttons and typed error handling. The browser’s Web Speech API is the default,
+						but a pluggable engine seam lets you swap in a cloud or on-device STT backend — even where
+						SpeechRecognition is missing. Every card below is live; open “View source” to see the exact
+						code.
 					</p>
 					<div className="intro__meta">
-						<span>Click a mic and speak — recognition happens in your browser.</span>
+						<span>
+							Click a mic and speak — recognition runs in your browser, or in a cloud engine you plug in.
+						</span>
 						<a
 							href="https://github.com/untemps/react-vocal#readme"
 							target="_blank"

--- a/dev/src/App.tsx
+++ b/dev/src/App.tsx
@@ -34,14 +34,12 @@ export const App = () => {
 						Web Speech API + custom engines · React
 					</span>
 					<h1>
-						Add voice to any React UI, in <span className="accent">one component</span>.
+						Speech recognition for React, in <span className="accent">one component</span>.
 					</h1>
 					<p>
-						react-vocal turns speech recognition into a component and a hook — voice commands, live
-						dictation, custom buttons and typed error handling. The browser’s Web Speech API is the default,
-						but a pluggable engine seam lets you swap in a cloud or on-device STT backend — even where
-						SpeechRecognition is missing. Every card below is live; open “View source” to see the exact
-						code.
+						Voice commands, live dictation, custom buttons and typed errors — plus a pluggable engine seam
+						that swaps the browser’s Web Speech API for a cloud or on-device backend. Every card is live;
+						open “View source” for the code.
 					</p>
 					<div className="intro__meta">
 						<span>

--- a/dev/src/App.tsx
+++ b/dev/src/App.tsx
@@ -34,7 +34,9 @@ export const App = () => {
 						Web Speech API + custom engines · React
 					</span>
 					<h1>
-						Speech recognition for React, in <span className="accent">one&nbsp;component</span>.
+						Speech recognition for React,
+						<br />
+						in <span className="accent">one&nbsp;component</span>.
 					</h1>
 					<p>
 						Voice commands, live dictation, custom buttons and typed errors — plus a pluggable engine seam

--- a/dev/src/cards/SupportCard.tsx
+++ b/dev/src/cards/SupportCard.tsx
@@ -15,7 +15,7 @@ export const SupportCard = ({ supported }: { supported: boolean }) => (
 	<Card
 		title="Feature detection"
 		badge="isSupported"
-		description="Before showing a mic, call isSupported(). It returns true only when the browser exposes the Web Speech API and microphone access — the single check that drives graceful degradation across this whole page."
+		description="Before showing a mic, call isSupported(). With no argument it returns true only when the browser exposes the Web Speech API and microphone access; pass a custom engine factory and it probes that backend instead. The single check that drives graceful degradation across this whole page."
 		code={CODE}
 	>
 		<div className="card__stage card__stage--center">
@@ -23,8 +23,9 @@ export const SupportCard = ({ supported }: { supported: boolean }) => (
 				{supported ? 'Supported in this browser' : 'Not available in this browser'}
 			</Pill>
 			<p className="hint">
-				Works in Chrome, Edge and Safari. Firefox doesn’t ship <code>SpeechRecognition</code>, and every browser
-				needs a secure context (HTTPS, or localhost).
+				Works in Chrome, Edge and Safari. Firefox doesn’t ship <code>SpeechRecognition</code> — but a custom
+				engine (see the Gladia card) brings recognition there too. Every browser still needs a secure context
+				(HTTPS, or localhost).
 			</p>
 		</div>
 	</Card>

--- a/dev/src/components/SupportBanner.tsx
+++ b/dev/src/components/SupportBanner.tsx
@@ -7,7 +7,7 @@ export const SupportBanner = ({ supported }: { supported: boolean }) =>
 			<span>
 				Speech recognition runs on a <strong>remote service</strong> (Google in Chrome, Apple in Safari), so it
 				needs a network connection and a <strong>secure context</strong> (HTTPS, or localhost). Under the hood
-				it uses <code>webkitSpeechRecognition</code>.
+				it uses <code>webkitSpeechRecognition</code> by default — or any custom STT engine you plug in.
 			</span>
 		</div>
 	) : (
@@ -15,8 +15,9 @@ export const SupportBanner = ({ supported }: { supported: boolean }) =>
 			<InfoIcon size={18} className="banner__icon" />
 			<span>
 				This browser doesn’t expose the <strong>Web Speech API</strong> (Firefox never shipped it; it also needs
-				HTTPS). The microphone cards are disabled here, but the <strong>typed</strong> cards below —{' '}
-				<code>useCommands</code> and the fallback input — work everywhere.
+				HTTPS), so the built-in mic cards are disabled here. But the <strong>Custom engine (Gladia)</strong>{' '}
+				card still works (a pluggable engine doesn’t rely on <code>SpeechRecognition</code>), and the{' '}
+				<strong>typed</strong> cards below — <code>useCommands</code> and the fallback input — work everywhere.
 			</span>
 		</div>
 	)

--- a/dev/src/styles/app.css
+++ b/dev/src/styles/app.css
@@ -174,7 +174,6 @@
 .intro h1 {
 	margin-top: var(--space-3);
 	font-size: var(--step-4);
-	max-width: 16ch;
 }
 .intro h1 .accent {
 	color: var(--brand-red);


### PR DESCRIPTION
## Contexte

L'audit de la démo a conclu que le contenu est à jour et sans dette technique, mais que **l'éditorial ne mentionnait que l'API Web Speech / `SpeechRecognition`**, sans mettre en avant la capacité 2.x à **brancher d'autres moteurs STT** (le différenciateur, désormais dans la description npm).

Cette PR corrige **uniquement le texte** — aucune nouvelle carte de démo.

## Changements (`dev/`)

| Endroit | Avant | Après |
|---|---|---|
| **Eyebrow** `App.tsx` | `Web Speech API · React` | `Web Speech API + custom engines · React` |
| **Intro** `App.tsx` | « react-vocal *wraps the browser's SpeechRecognition* » | Web Speech API présentée comme **défaut**, + « pluggable engine seam » (cloud/on-device, même sans `SpeechRecognition`) |
| **Intro meta** `App.tsx` | « recognition happens in your browser » | « …in your browser, **or in a cloud engine you plug in** » |
| **Bandeau supporté** `SupportBanner` | « …uses `webkitSpeechRecognition`. » | « …**by default — or any custom STT engine you plug in**. » |
| **Bandeau NON supporté** `SupportBanner` | « mic cards disabled… only *typed* cards work » | pointe vers la **carte Custom engine (Gladia)** qui fonctionne sans `SpeechRecognition` |
| **Feature detection** `SupportCard` | isSupported() = Web Speech only | documente `isSupported(engineFactory)` + Firefox via moteur custom |

### Correction de justesse (pas seulement du wording)

Le bandeau « navigateur non supporté » affirmait que **seules** les cartes *typed* fonctionnent — c'était **faux** : la carte Gladia calcule son propre support via `isSupported(engineFactory)` et tourne dans Firefox (un moteur enfichable ne dépend pas de `SpeechRecognition`). Le texte le reflète désormais.

## Vérification

- `cd dev && yarn typecheck` → OK (JSX valide).
- Formatage prettier appliqué par le hook pre-commit.

## Notes

- Changement **`dev/` uniquement** : pas d'impact npm (le dossier `dev/` n'est pas publié). Se déploiera sur la démo Vercel au merge.
- Wording proposé — n'hésite pas à ajuster directement sur la PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
